### PR TITLE
Freeze transcriptions generation format to CSV and deprecate meta.json

### DIFF
--- a/preparation/acoustic_preparation.ipynb
+++ b/preparation/acoustic_preparation.ipynb
@@ -72,6 +72,7 @@
     "import os\n",
     "import shutil\n",
     "import sys\n",
+    "\n",
     "import librosa\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",

--- a/preparation/acoustic_preparation.ipynb
+++ b/preparation/acoustic_preparation.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -46,6 +47,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -67,11 +69,9 @@
    "source": [
     "import csv\n",
     "import glob\n",
-    "import json\n",
     "import os\n",
     "import shutil\n",
     "import sys\n",
-    "\n",
     "import librosa\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
@@ -96,6 +96,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -153,6 +154,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -226,6 +228,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -270,6 +273,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -301,6 +305,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -310,6 +315,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -340,6 +346,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -376,6 +383,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -473,6 +481,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -518,6 +527,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -587,6 +597,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -787,6 +798,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -866,6 +878,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -877,9 +890,7 @@
     "\n",
     "Please provide a unique name for your dataset, usually the name of the singer/speaker (whether real or virtual). For example, `opencpop` will be a good name for the dataset. You can also add tags to represent dataset version, model capacity or improvements. For example, `v2` represents the version, `large` represents the capacity, and `fix_br` means you fixed breaths since your trained last model.\n",
     "\n",
-    "Please edit the following cell before you run it. Remember only using letters, numbers and underlines (`_`).\n",
-    "\n",
-    "Formatting of the data labels: `csv` is a more comprehensive format that is newly introduced to this pipeline. If you want to generate old label format where attributes are seperated by `|`, please change it to `grid` in the following cell.\n"
+    "Please edit the following cell before you run it. Remember only using letters, numbers and underlines (`_`).\n"
    ]
   },
   {
@@ -899,9 +910,6 @@
     "dataset_name = '???'  # Required\n",
     "dataset_tags = ''  # Optional\n",
     "\n",
-    "# Label format (will only use 'csv' in the future)\n",
-    "label_format = 'csv'\n",
-    "\n",
     "########################################\n",
     "\n",
     "import csv\n",
@@ -917,8 +925,6 @@
     "    assert re.search(r'[^0-9A-Za-z_]', dataset_name) is None, 'Dataset tags contain invalid characters.'\n",
     "    full_name += f'_{dataset_tags}'\n",
     "assert not os.path.exists(f'../data/{full_name}'), f'The name \\'{full_name}\\' already exists in your \\'data\\' folder!'\n",
-    "\n",
-    "assert label_format in ['csv', 'grid'], 'Label format must be \\'csv\\' or \\'grid\\'.'\n",
     "\n",
     "print('Dataset name:', dataset_name)\n",
     "if dataset_tags != '':\n",
@@ -956,23 +962,9 @@
     "    ph_seq = ' '.join(ph_seq)\n",
     "    ph_dur = ' '.join([str(round(d, 6)) for d in ph_dur])\n",
     "    soundfile.write(os.path.join(formatted_path, f'{name}.wav'), y, samplerate)\n",
-    "    if label_format == 'grid':\n",
-    "        transcriptions.append(f'{name}|啊|{ph_seq}|rest|0|{ph_dur}|0')\n",
-    "    else:\n",
-    "        transcriptions.append({'name': name, 'ph_seq': ph_seq, 'ph_dur': ph_dur})\n",
+    "    transcriptions.append({'name': name, 'ph_seq': ph_seq, 'ph_dur': ph_dur})\n",
     "\n",
-    "with open(f'../data/{full_name}/raw/meta.json', 'w', encoding='utf8') as f:\n",
-    "    meta = {\n",
-    "        'category': 'acoustic',\n",
-    "        'format': label_format\n",
-    "    }\n",
-    "    json.dump(meta, f, indent=4)\n",
-    "\n",
-    "if label_format == 'grid':\n",
-    "    with open(f'../data/{full_name}/raw/transcriptions.txt', 'w', encoding='utf8') as f:\n",
-    "        print('\\n'.join(transcriptions), file=f)\n",
-    "else:\n",
-    "    with open(f'../data/{full_name}/raw/transcriptions.csv', 'w', encoding='utf8', newline='') as f:\n",
+    "with open(f'../data/{full_name}/raw/transcriptions.csv', 'w', encoding='utf8', newline='') as f:\n",
     "        writer = csv.DictWriter(f, fieldnames=['name', 'ph_seq', 'ph_dur'])\n",
     "        writer.writeheader()\n",
     "        writer.writerows(transcriptions)\n",
@@ -981,6 +973,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1021,6 +1014,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": []
@@ -1302,6 +1296,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1398,6 +1393,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/preprocessing/acoustic_binarizer.py
+++ b/preprocessing/acoustic_binarizer.py
@@ -47,7 +47,7 @@ class AcousticBinarizer(BaseBinarizer):
             f'but a dataset of category \'acoustic\' is required.'
 
         meta_data_dict = {}
-        if meta_info['format'] == 'csv':
+        if meta_info['format'] == 'csv' or os.path.exists(raw_data_dir / 'transcriptions.csv'):
             for utterance_label in csv.DictReader(
                     open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf-8')
             ):

--- a/preprocessing/acoustic_binarizer.py
+++ b/preprocessing/acoustic_binarizer.py
@@ -7,7 +7,6 @@
     ph_dur: phoneme durations
 """
 import csv
-import json
 import os
 import pathlib
 import random
@@ -34,20 +33,8 @@ class AcousticBinarizer(BaseBinarizer):
         self.lr = LengthRegulator()
 
     def load_meta_data(self, raw_data_dir: pathlib.Path, ds_id):
-        meta_info = {
-            'category': 'acoustic',
-            'format': 'grid'
-        }
-        meta_file = raw_data_dir / 'meta.json'
-        if meta_file.exists():
-            meta_info.update(json.load(open(meta_file, 'r', encoding='utf8')))
-        category = meta_info['category']
-        assert category == 'acoustic', \
-            f'Dataset in \'{raw_data_dir}\' is of category \'{category}\', ' \
-            f'but a dataset of category \'acoustic\' is required.'
-
         meta_data_dict = {}
-        if meta_info['format'] == 'csv' or os.path.exists(raw_data_dir / 'transcriptions.csv'):
+        if (raw_data_dir / 'transcriptions.csv').exists():
             for utterance_label in csv.DictReader(
                     open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf-8')
             ):


### PR DESCRIPTION
add "os.path.exists(path)" to determine whether to read "transcriptions.csv" or "transcriptions.txt".