### PR TITLE
Change variance retaking masks from zero inputs to zero embeddings

### DIFF
--- a/deployment/modules/toplevel.py
+++ b/deployment/modules/toplevel.py
@@ -156,10 +156,10 @@ class DiffSingerVarianceONNX(DiffSingerVariance):
             pitch=None, retake=None
     ):
         condition = self.forward_mel2x_gather(encoder_out, ph_dur, x_dim=self.hidden_size)
-        condition += self.retake_embed(retake.long())
+        condition += self.pitch_retake_embed(retake.long())
         frame_midi_pitch = self.forward_mel2x_gather(note_midi, note_dur, x_dim=None)
         base_pitch = self.smooth(frame_midi_pitch)
-        base_pitch += (pitch - base_pitch) * ~retake
+        base_pitch = base_pitch * retake + pitch * ~retake
         pitch_cond = condition + self.base_pitch_embed(base_pitch[:, :, None])
         return pitch_cond, base_pitch
 
@@ -177,12 +177,14 @@ class DiffSingerVarianceONNX(DiffSingerVariance):
             self, encoder_out, ph_dur, pitch, variances: dict = None, retake=None
     ):
         condition = self.forward_mel2x_gather(encoder_out, ph_dur, x_dim=self.hidden_size)
-        condition += self.retake_embed(retake.long())
         variance_cond = condition + self.pitch_embed(pitch[:, :, None])
-        non_retake_masks = (~retake)[:, :, None].float()
+        non_retake_masks = [
+            v_retake.float()  # [B, T, 1]
+            for v_retake in (~retake).split(1, dim=2)
+        ]
         variance_embeds = [
-            self.variance_embeds[v_name](variances[v_name][:, :, None]) * non_retake_masks
-            for v_name in self.variance_prediction_list
+            self.variance_embeds[v_name](variances[v_name][:, :, None]) * v_masks
+            for v_name, v_masks in zip(self.variance_prediction_list, non_retake_masks)
         ]
         variance_cond += torch.stack(variance_embeds, dim=-1).sum(-1)
         return variance_cond

--- a/deployment/modules/toplevel.py
+++ b/deployment/modules/toplevel.py
@@ -179,9 +179,9 @@ class DiffSingerVarianceONNX(DiffSingerVariance):
         condition = self.forward_mel2x_gather(encoder_out, ph_dur, x_dim=self.hidden_size)
         condition += self.retake_embed(retake.long())
         variance_cond = condition + self.pitch_embed(pitch[:, :, None])
-        non_retake = (~retake).float()
+        non_retake_masks = (~retake)[:, :, None].float()
         variance_embeds = [
-            self.variance_embeds[v_name]((variances[v_name] * non_retake)[:, :, None])
+            self.variance_embeds[v_name](variances[v_name][:, :, None]) * non_retake_masks
             for v_name in self.variance_prediction_list
         ]
         variance_cond += torch.stack(variance_embeds, dim=-1).sum(-1)

--- a/inference/ds_variance.py
+++ b/inference/ds_variance.py
@@ -256,7 +256,7 @@ class DiffSingerVarianceInfer(BaseSVSInfer):
             txt_tokens, midi=midi, ph2word=ph2word, word_dur=word_dur, ph_dur=ph_dur,
             mel2ph=mel2ph, base_pitch=base_pitch, pitch=pitch,
             ph_spk_mix_embed=ph_spk_mix_embed, spk_mix_embed=spk_mix_embed,
-            retake=None, infer=True
+            infer=True
         )
         if dur_pred is not None:
             dur_pred = self.rr(dur_pred, ph2word, word_dur)

--- a/modules/toplevel.py
+++ b/modules/toplevel.py
@@ -1,6 +1,9 @@
+from typing import Dict
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch import Tensor
 
 from basics.base_module import CategorizedModule
 from modules.commons.common_layers import (
@@ -69,6 +72,7 @@ class DiffSingerVariance(ParameterAdaptorModule, CategorizedModule):
     def __init__(self, vocab_size):
         super().__init__()
         self.predict_dur = hparams['predict_dur']
+        self.predict_pitch = hparams['predict_pitch']
 
         self.use_spk_id = hparams['use_spk_id']
         if self.use_spk_id:
@@ -80,12 +84,8 @@ class DiffSingerVariance(ParameterAdaptorModule, CategorizedModule):
         self.rr = RhythmRegulator()
         self.lr = LengthRegulator()
 
-        self.predict_pitch = hparams['predict_pitch']
-
-        if self.predict_pitch or self.predict_variances:
-            self.retake_embed = Embedding(2, hparams['hidden_size'], padding_idx=0)
-
         if self.predict_pitch:
+            self.pitch_retake_embed = Embedding(2, hparams['hidden_size'], padding_idx=0)
             pitch_hparams = hparams['pitch_prediction_args']
             self.base_pitch_embed = Linear(1, hparams['hidden_size'])
             self.pitch_predictor = PitchDiffusion(
@@ -114,7 +114,8 @@ class DiffSingerVariance(ParameterAdaptorModule, CategorizedModule):
 
     def forward(
             self, txt_tokens, midi, ph2word, ph_dur=None, word_dur=None, mel2ph=None,
-            base_pitch=None, pitch=None, retake=None, spk_id=None, infer=True, **kwargs
+            base_pitch=None, pitch=None, pitch_retake=None, variance_retake: Dict[str, Tensor] = None,
+            spk_id=None, infer=True, **kwargs
     ):
         if self.use_spk_id:
             ph_spk_mix_embed = kwargs.get('ph_spk_mix_embed')
@@ -147,16 +148,13 @@ class DiffSingerVariance(ParameterAdaptorModule, CategorizedModule):
 
         if self.use_spk_id:
             condition += spk_embed
-        if retake is None:
-            retake_embed = self.retake_embed(torch.ones_like(mel2ph))
-        else:
-            retake_embed = self.retake_embed(retake.long())
-        condition += retake_embed
 
         if self.predict_pitch:
-            if retake is not None:
-                base_pitch = base_pitch * retake + pitch * ~retake
-            pitch_cond = condition + self.base_pitch_embed(base_pitch[:, :, None])
+            if pitch_retake is None:
+                pitch_retake = torch.ones_like(mel2ph, dtype=torch.bool)
+            pitch_cond = condition + self.pitch_retake_embed(pitch_retake.long())
+            base_pitch = base_pitch * pitch_retake + pitch * ~pitch_retake
+            pitch_cond += self.base_pitch_embed(base_pitch[:, :, None])
             if infer:
                 pitch_pred_out = self.pitch_predictor(pitch_cond, infer=True)
             else:
@@ -172,10 +170,9 @@ class DiffSingerVariance(ParameterAdaptorModule, CategorizedModule):
         condition += self.pitch_embed(pitch[:, :, None])
 
         variance_inputs = self.collect_variance_inputs(**kwargs)
-        if retake is not None:
-            non_retake_masks = (~retake)[:, :, None].float()
+        if variance_retake is not None:
             variance_embeds = [
-                self.variance_embeds[v_name](v_input[:, :, None]) * non_retake_masks
+                self.variance_embeds[v_name](v_input[:, :, None]) * ~variance_retake[v_name][:, :, None]
                 for v_name, v_input in zip(self.variance_prediction_list, variance_inputs)
             ]
             condition += torch.stack(variance_embeds, dim=-1).sum(-1)

--- a/modules/toplevel.py
+++ b/modules/toplevel.py
@@ -85,7 +85,7 @@ class DiffSingerVariance(ParameterAdaptorModule, CategorizedModule):
         self.lr = LengthRegulator()
 
         if self.predict_pitch:
-            self.pitch_retake_embed = Embedding(2, hparams['hidden_size'], padding_idx=0)
+            self.pitch_retake_embed = Embedding(2, hparams['hidden_size'])
             pitch_hparams = hparams['pitch_prediction_args']
             self.base_pitch_embed = Linear(1, hparams['hidden_size'])
             self.pitch_predictor = PitchDiffusion(

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -53,6 +53,13 @@ class VarianceDataset(BaseDataset):
         return batch
 
 
+def random_retake_masks(b, t, device):
+    B_masks = torch.randint(low=0, high=4, size=(b, 1), dtype=torch.long) == 0  # 1/4 segments are True in average
+    T_masks = utils.random_continuous_masks(shape=(b, t), dim=1, device=device)  # 1/3 frames are True in average
+    masks = B_masks | T_masks  # 1/4 segments and 1/2 frames are True in average (1/4 + 3/4 * 1/3 = 1/2)
+    return masks
+
+
 class VarianceTask(BaseTask):
     def __init__(self):
         super().__init__()
@@ -122,10 +129,10 @@ class VarianceTask(BaseTask):
             t = mel2ph.shape[1]
             device = mel2ph.device
             if self.predict_pitch:
-                pitch_retake = utils.random_continuous_masks(b, t, device)
+                pitch_retake = random_retake_masks(b, t, device)
             if self.predict_variances:
                 variance_retake = {
-                    v_name: utils.random_continuous_masks(b, t, device)
+                    v_name: random_retake_masks(b, t, device)
                     for v_name in self.variance_prediction_list
                 }
 

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -54,10 +54,12 @@ class VarianceDataset(BaseDataset):
 
 
 def random_retake_masks(b, t, device):
-    B_masks = torch.randint(low=0, high=4, size=(b, 1), dtype=torch.long) == 0  # 1/4 segments are True in average
-    T_masks = utils.random_continuous_masks(shape=(b, t), dim=1, device=device)  # 1/3 frames are True in average
-    masks = B_masks | T_masks  # 1/4 segments and 1/2 frames are True in average (1/4 + 3/4 * 1/3 = 1/2)
-    return masks
+    # 1/4 segments are True in average
+    B_masks = torch.randint(low=0, high=4, size=(b, 1), dtype=torch.long, device=device) == 0
+    # 1/3 frames are True in average
+    T_masks = utils.random_continuous_masks(shape=(b, t), dim=1, device=device)
+    # 1/4 segments and 1/2 frames are True in average (1/4 + 3/4 * 1/3 = 1/2)
+    return B_masks | T_masks
 
 
 class VarianceTask(BaseTask):

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -57,7 +57,7 @@ def random_retake_masks(b, t, device):
     # 1/4 segments are True in average
     B_masks = torch.randint(low=0, high=4, size=(b, 1), dtype=torch.long, device=device) == 0
     # 1/3 frames are True in average
-    T_masks = utils.random_continuous_masks(shape=(b, t), dim=1, device=device)
+    T_masks = utils.random_continuous_masks(b, t, dim=1, device=device)
     # 1/4 segments and 1/2 frames are True in average (1/4 + 3/4 * 1/3 = 1/2)
     return B_masks | T_masks
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -36,7 +36,7 @@ def collate_nd(values, pad_value=0, max_len=None):
     return res
 
 
-def random_continuous_masks(shape: tuple, dim: int, device: str | torch.device = 'cpu'):
+def random_continuous_masks(*shape: int, dim: int, device: str | torch.device = 'cpu'):
     start, end = torch.sort(
         torch.randint(
             low=0, high=shape[dim] + 1, size=(*shape[:dim], 2, *((1,) * (len(shape) - dim - 1))), device=device

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pathlib
 import re
 import time
@@ -34,12 +36,15 @@ def collate_nd(values, pad_value=0, max_len=None):
     return res
 
 
-def random_continuous_masks(b, t, device):
-    # randomly select continuous retaking regions
+def random_continuous_masks(shape: tuple, dim: int, device: str | torch.device = 'cpu'):
     start, end = torch.sort(
-        torch.randint(low=0, high=t + 1, size=(b, 2), device=device), dim=1
-    )[0].split(1, dim=1)
-    idx = torch.arange(0, t, dtype=torch.long, device=device)[None]
+        torch.randint(
+            low=0, high=shape[dim] + 1, size=(*shape[:dim], 2, *((1,) * (len(shape) - dim - 1))), device=device
+        ).expand(*((-1,) * (dim + 1)), *shape[dim + 1:]), dim=dim
+    )[0].split(1, dim=dim)
+    idx = torch.arange(
+        0, shape[dim], dtype=torch.long, device=device
+    ).reshape(*((1,) * dim), shape[dim], *((1,) * (len(shape) - dim - 1)))
     masks = (idx >= start) & (idx < end)
     return masks
 

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -34,6 +34,16 @@ def collate_nd(values, pad_value=0, max_len=None):
     return res
 
 
+def random_continuous_masks(b, t, device):
+    # randomly select continuous retaking regions
+    start, end = torch.sort(
+        torch.randint(low=0, high=t + 1, size=(b, 2), device=device), dim=1
+    )[0].split(1, dim=1)
+    idx = torch.arange(0, t, dtype=torch.long, device=device)[None]
+    masks = (idx >= start) & (idx < end)
+    return masks
+
+
 def _is_batch_full(batch, num_frames, max_batch_frames, max_batch_size):
     if len(batch) == 0:
         return 0


### PR DESCRIPTION
There are 4 modifications to the variance retaking mechanism in this pull request:

1. Zero masks are applied to embeddings instead of inputs.
2. The retaking embedding for variance parameters is removed.
3. Masks of each variance parameter are decoupled so that they can be retaken separately.
4. Generation algorithm of retaking masks is improved.

NOTE: These modifications are backward-incompatible. All models involving pitch and variance predictions need to be re-trained.