### PR TITLE
Multi-node batched validation and improvement on strategy selection

### DIFF
--- a/basics/base_binarizer.py
+++ b/basics/base_binarizer.py
@@ -1,5 +1,6 @@
 import json
 import pathlib
+import pickle
 import random
 import shutil
 import warnings
@@ -94,55 +95,54 @@ class BaseBinarizer:
     def load_meta_data(self, raw_data_dir: pathlib.Path, ds_id, spk_id):
         raise NotImplementedError()
 
-    def split_train_valid_set(self):
+    def split_train_valid_set(self, item_names):
         """
         Split the dataset into training set and validation set.
         :return: train_item_names, valid_item_names
         """
-        prefixes = set([str(pr) for pr in hparams['test_prefixes']])
-        valid_item_names = set()
+        prefixes = {str(pr): None for pr in hparams['test_prefixes']}
+        valid_item_names = []
         # Add prefixes that specified speaker index and matches exactly item name to test set
         for prefix in deepcopy(prefixes):
-            if prefix in self.item_names:
-                valid_item_names.add(prefix)
-                prefixes.remove(prefix)
+            if prefix in item_names:
+                valid_item_names.append(prefix)
+                prefixes.pop(prefix)
         # Add prefixes that exactly matches item name without speaker id to test set
         for prefix in deepcopy(prefixes):
             matched = False
-            for name in self.item_names:
+            for name in item_names:
                 if name.split(':')[-1] == prefix:
-                    valid_item_names.add(name)
+                    valid_item_names.append(name)
                     matched = True
             if matched:
-                prefixes.remove(prefix)
+                prefixes.pop(prefix)
         # Add names with one of the remaining prefixes to test set
         for prefix in deepcopy(prefixes):
             matched = False
-            for name in self.item_names:
+            for name in item_names:
                 if name.startswith(prefix):
-                    valid_item_names.add(name)
+                    valid_item_names.append(name)
                     matched = True
             if matched:
-                prefixes.remove(prefix)
+                prefixes.pop(prefix)
         for prefix in deepcopy(prefixes):
             matched = False
-            for name in self.item_names:
+            for name in item_names:
                 if name.split(':')[-1].startswith(prefix):
-                    valid_item_names.add(name)
+                    valid_item_names.append(name)
                     matched = True
             if matched:
-                prefixes.remove(prefix)
+                prefixes.pop(prefix)
 
         if len(prefixes) != 0:
             warnings.warn(
-                f'The following rules in test_prefixes have no matching names in the dataset: {sorted(prefixes)}',
+                f'The following rules in test_prefixes have no matching names in the dataset: {prefixes}',
                 category=UserWarning
             )
             warnings.filterwarnings('default')
 
-        valid_item_names = sorted(list(valid_item_names))
         assert len(valid_item_names) > 0, 'Validation set is empty!'
-        train_item_names = [x for x in self.item_names if x not in set(valid_item_names)]
+        train_item_names = [x for x in item_names if x not in set(valid_item_names)]
         assert len(train_item_names) > 0, 'Training set is empty!'
 
         return train_item_names, valid_item_names
@@ -169,7 +169,7 @@ class BaseBinarizer:
         for ds_id, spk_id, data_dir in zip(range(len(self.raw_data_dirs)), self.spk_ids, self.raw_data_dirs):
             self.load_meta_data(pathlib.Path(data_dir), ds_id=ds_id, spk_id=spk_id)
         self.item_names = sorted(list(self.items.keys()))
-        self._train_item_names, self._valid_item_names = self.split_train_valid_set()
+        self._train_item_names, self._valid_item_names = self.split_train_valid_set(self.item_names)
 
         if self.binarization_args['shuffle']:
             random.seed(hparams['seed'])
@@ -249,9 +249,9 @@ class BaseBinarizer:
     def process_dataset(self, prefix, num_workers=0, apply_augmentation=False):
         args = []
         builder = IndexedDatasetBuilder(self.binary_data_dir, prefix=prefix, allowed_attr=self.data_attrs)
-        lengths = []
-        total_sec = 0
-        total_raw_sec = 0
+        total_sec = {k: 0.0 for k in self.spk_map}
+        total_raw_sec = {k: 0.0 for k in self.spk_map}
+        extra_info = {'name': {}, 'spk_ids': {}, 'spk': {}, 'lengths': {}}
 
         for item_name, meta_data in self.meta_data_iterator(prefix):
             args.append([item_name, meta_data, self.binarization_args])
@@ -259,19 +259,35 @@ class BaseBinarizer:
         aug_map = self.arrange_data_augmentation(self.meta_data_iterator(prefix)) if apply_augmentation else {}
 
         def postprocess(_item):
-            nonlocal total_sec, total_raw_sec
+            nonlocal total_sec, total_raw_sec, extra_info
             if _item is None:
                 return
-            builder.add_item(_item)
-            lengths.append(_item['length'])
-            total_sec += _item['seconds']
-            total_raw_sec += _item['seconds']
+            item_no = builder.add_item(_item)
+            for k, v in _item.items():
+                if isinstance(v, np.ndarray):
+                    if k not in extra_info:
+                        extra_info[k] = {}
+                    extra_info[k][item_no] = v.shape[0]
+            extra_info['name'][item_no] = _item['name'].split(':', 1)[-1]
+            extra_info['spk_ids'][item_no] = _item['spk_id']
+            extra_info['spk'][item_no] = _item['spk']
+            extra_info['lengths'][item_no] = _item['length']
+            total_raw_sec[_item['spk']] += _item['seconds']
+            total_sec[_item['spk']] += _item['seconds']
 
             for task in aug_map.get(_item['name'], []):
                 aug_item = task['func'](_item, **task['kwargs'])
-                builder.add_item(aug_item)
-                lengths.append(aug_item['length'])
-                total_sec += aug_item['seconds']
+                aug_item_no = builder.add_item(aug_item)
+                for k, v in aug_item.items():
+                    if isinstance(v, np.ndarray):
+                        if k not in extra_info:
+                            extra_info[k] = {}
+                        extra_info[k][aug_item_no] = v.shape[0]
+                extra_info['name'][aug_item_no] = aug_item['name'].split(':', 1)[-1]
+                extra_info['spk_ids'][aug_item_no] = aug_item['spk_id']
+                extra_info['spk'][aug_item_no] = aug_item['spk']
+                extra_info['lengths'][aug_item_no] = aug_item['length']
+                total_sec[aug_item['spk']] += aug_item['seconds']
 
         try:
             if num_workers > 0:
@@ -286,21 +302,34 @@ class BaseBinarizer:
                 for a in tqdm(args):
                     item = self.process_item(*a)
                     postprocess(item)
+            for k in extra_info:
+                for item_no in range(len(args)):
+                    assert item_no in extra_info[k], f'Item numbering is not consecutive.'
+                extra_info[k] = list(map(lambda x: x[1], sorted(extra_info[k].items(), key=lambda x: x[0])))
         except KeyboardInterrupt:
             builder.finalize()
             raise
 
         builder.finalize()
-        with open(self.binary_data_dir / f'{prefix}.lengths', 'wb') as f:
+        if prefix == "train":
+            extra_info.pop("name")
+            extra_info.pop("spk")
+        with open(self.binary_data_dir / f"{prefix}.meta", "wb") as f:
             # noinspection PyTypeChecker
-            np.save(f, lengths)
-
+            pickle.dump(extra_info, f)
         if apply_augmentation:
-            print(f'| {prefix} total duration (before augmentation): {total_raw_sec:.2f}s')
+            print(f"| {prefix} total duration (before augmentation): {sum(total_raw_sec.values()):.2f}s")
+            for k, v in total_raw_sec.items():
+                print(f"|     {k}: {v:.2f}s")
             print(
-                f'| {prefix} total duration (after augmentation): {total_sec:.2f}s ({total_sec / total_raw_sec:.2f}x)')
+                f"| {prefix} total duration (after augmentation): {sum(total_sec.values()):.2f}s ({sum(total_sec.values()) / sum(total_raw_sec.values()):.2f}x)"
+            )
+            for k, v in total_sec.items():
+                print(f"|     {k}: {v:.2f}s")
         else:
-            print(f'| {prefix} total duration: {total_raw_sec:.2f}s')
+            print(f"| {prefix} total duration: {sum(total_raw_sec.values()):.2f}s")
+            for k, v in total_raw_sec.items():
+                print(f"|     {k}: {v:.2f}s")
 
     def arrange_data_augmentation(self, data_iterator):
         """

--- a/basics/base_binarizer.py
+++ b/basics/base_binarizer.py
@@ -252,7 +252,7 @@ class BaseBinarizer:
         builder = IndexedDatasetBuilder(self.binary_data_dir, prefix=prefix, allowed_attr=self.data_attrs)
         total_sec = {k: 0.0 for k in self.spk_map}
         total_raw_sec = {k: 0.0 for k in self.spk_map}
-        extra_info = {'name': {}, 'spk_ids': {}, 'spk': {}, 'lengths': {}}
+        extra_info = {'names': {}, 'spk_ids': {}, 'spk_names': {}, 'lengths': {}}
 
         for item_name, meta_data in self.meta_data_iterator(prefix):
             args.append([item_name, meta_data, self.binarization_args])
@@ -269,12 +269,12 @@ class BaseBinarizer:
                     if k not in extra_info:
                         extra_info[k] = {}
                     extra_info[k][item_no] = v.shape[0]
-            extra_info['name'][item_no] = _item['name'].split(':', 1)[-1]
+            extra_info['names'][item_no] = _item['name'].split(':', 1)[-1]
             extra_info['spk_ids'][item_no] = _item['spk_id']
-            extra_info['spk'][item_no] = _item['spk']
+            extra_info['spk_names'][item_no] = _item['spk_name']
             extra_info['lengths'][item_no] = _item['length']
-            total_raw_sec[_item['spk']] += _item['seconds']
-            total_sec[_item['spk']] += _item['seconds']
+            total_raw_sec[_item['spk_name']] += _item['seconds']
+            total_sec[_item['spk_name']] += _item['seconds']
 
             for task in aug_map.get(_item['name'], []):
                 aug_item = task['func'](_item, **task['kwargs'])
@@ -284,11 +284,11 @@ class BaseBinarizer:
                         if k not in extra_info:
                             extra_info[k] = {}
                         extra_info[k][aug_item_no] = v.shape[0]
-                extra_info['name'][aug_item_no] = aug_item['name'].split(':', 1)[-1]
+                extra_info['names'][aug_item_no] = aug_item['name'].split(':', 1)[-1]
                 extra_info['spk_ids'][aug_item_no] = aug_item['spk_id']
-                extra_info['spk'][aug_item_no] = aug_item['spk']
+                extra_info['spk_names'][aug_item_no] = aug_item['spk_name']
                 extra_info['lengths'][aug_item_no] = aug_item['length']
-                total_sec[aug_item['spk']] += aug_item['seconds']
+                total_sec[aug_item['spk_name']] += aug_item['seconds']
 
         try:
             if num_workers > 0:
@@ -313,8 +313,8 @@ class BaseBinarizer:
 
         builder.finalize()
         if prefix == "train":
-            extra_info.pop("name")
-            extra_info.pop("spk")
+            extra_info.pop("names")
+            extra_info.pop("spk_names")
         with open(self.binary_data_dir / f"{prefix}.meta", "wb") as f:
             # noinspection PyTypeChecker
             pickle.dump(extra_info, f)

--- a/basics/base_binarizer.py
+++ b/basics/base_binarizer.py
@@ -136,16 +136,17 @@ class BaseBinarizer:
 
         if len(prefixes) != 0:
             warnings.warn(
-                f'The following rules in test_prefixes have no matching names in the dataset: {prefixes}',
+                f'The following rules in test_prefixes have no matching names in the dataset: {", ".join(prefixes.keys())}',
                 category=UserWarning
             )
             warnings.filterwarnings('default')
 
+        valid_item_names = list(valid_item_names.keys())
         assert len(valid_item_names) > 0, 'Validation set is empty!'
         train_item_names = [x for x in item_names if x not in set(valid_item_names)]
         assert len(train_item_names) > 0, 'Training set is empty!'
 
-        return train_item_names, list(valid_item_names)
+        return train_item_names, valid_item_names
 
     @property
     def train_item_names(self):

--- a/basics/base_binarizer.py
+++ b/basics/base_binarizer.py
@@ -100,19 +100,19 @@ class BaseBinarizer:
         Split the dataset into training set and validation set.
         :return: train_item_names, valid_item_names
         """
-        prefixes = {str(pr): None for pr in hparams['test_prefixes']}
-        valid_item_names = []
+        prefixes = {str(pr): 1 for pr in hparams['test_prefixes']}
+        valid_item_names = {}
         # Add prefixes that specified speaker index and matches exactly item name to test set
         for prefix in deepcopy(prefixes):
             if prefix in item_names:
-                valid_item_names.append(prefix)
+                valid_item_names[prefix] = 1
                 prefixes.pop(prefix)
         # Add prefixes that exactly matches item name without speaker id to test set
         for prefix in deepcopy(prefixes):
             matched = False
             for name in item_names:
                 if name.split(':')[-1] == prefix:
-                    valid_item_names.append(name)
+                    valid_item_names[name] = 1
                     matched = True
             if matched:
                 prefixes.pop(prefix)
@@ -121,7 +121,7 @@ class BaseBinarizer:
             matched = False
             for name in item_names:
                 if name.startswith(prefix):
-                    valid_item_names.append(name)
+                    valid_item_names[name] = 1
                     matched = True
             if matched:
                 prefixes.pop(prefix)
@@ -129,7 +129,7 @@ class BaseBinarizer:
             matched = False
             for name in item_names:
                 if name.split(':')[-1].startswith(prefix):
-                    valid_item_names.append(name)
+                    valid_item_names[name] = 1
                     matched = True
             if matched:
                 prefixes.pop(prefix)
@@ -145,7 +145,7 @@ class BaseBinarizer:
         train_item_names = [x for x in item_names if x not in set(valid_item_names)]
         assert len(train_item_names) > 0, 'Training set is empty!'
 
-        return train_item_names, valid_item_names
+        return train_item_names, list(valid_item_names)
 
     @property
     def train_item_names(self):

--- a/basics/base_dataset.py
+++ b/basics/base_dataset.py
@@ -1,7 +1,7 @@
 import os
 import pickle
 
-import numpy as np
+import torch
 from torch.utils.data import Dataset
 
 from utils.hparams import hparams
@@ -38,7 +38,7 @@ class BaseDataset(Dataset):
             self.indexed_ds = self._indexed_ds
 
     def __getitem__(self, index):
-        return self.indexed_ds[index]
+        return {'_idx': index, **self.indexed_ds[index]}
 
     def __len__(self):
         return len(self.sizes)
@@ -52,6 +52,10 @@ class BaseDataset(Dataset):
         return self.sizes[index]
 
     def collater(self, samples):
-        return {
-            'size': len(samples)
-        }
+        if samples:
+            return {
+                'size': len(samples),
+                'indices': torch.LongTensor([s['_idx'] for s in samples])
+            }
+        else:
+            return {'size': 0}

--- a/basics/base_dataset.py
+++ b/basics/base_dataset.py
@@ -52,10 +52,7 @@ class BaseDataset(Dataset):
         return self.sizes[index]
 
     def collater(self, samples):
-        if samples:
-            return {
-                'size': len(samples),
-                'indices': torch.LongTensor([s['_idx'] for s in samples])
-            }
-        else:
-            return {'size': 0}
+        return {
+            'size': len(samples),
+            'indices': torch.LongTensor([s['_idx'] for s in samples])
+        }

--- a/basics/base_task.py
+++ b/basics/base_task.py
@@ -219,7 +219,7 @@ class BaseTask(pl.LightningModule):
         total_loss = sum(losses.values())
         return total_loss, {**losses, 'batch_size': float(sample['size'])}
 
-    def training_step(self, sample, batch_idx, optimizer_idx=-1):
+    def training_step(self, sample, batch_idx):
         total_loss, log_outputs = self._training_step(sample)
 
         # logs to progress bar
@@ -241,7 +241,7 @@ class BaseTask(pl.LightningModule):
 
     def on_validation_start(self):
         if self.skip_immediate_validation:
-            rank_zero_debug(f"Skip validation")
+            rank_zero_debug("Skip validation")
             return
         self._on_validation_start()
         for metric in self.valid_losses.values():
@@ -267,7 +267,7 @@ class BaseTask(pl.LightningModule):
         :param batch_idx:
         """
         if self.skip_immediate_validation:
-            rank_zero_debug(f"Skip validation {batch_idx}")
+            rank_zero_debug("Skip validation")
             return
         if sample['size'] > 0:
             with torch.autocast(self.device.type, enabled=False):

--- a/basics/base_task.py
+++ b/basics/base_task.py
@@ -17,15 +17,13 @@ import torch.utils.data
 from torchmetrics import Metric, MeanMetric
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks import LearningRateMonitor
-from lightning.pytorch.loggers import TensorBoardLogger
 from lightning.pytorch.utilities.rank_zero import rank_zero_debug, rank_zero_info, rank_zero_only
 
 from basics.base_module import CategorizedModule
 from utils.hparams import hparams
 from utils.training_utils import (
     DsModelCheckpoint, DsTQDMProgressBar,
-    DsBatchSampler, DsEvalBatchSampler,
-    DsTensorBoardLogger,
+    DsBatchSampler, DsTensorBoardLogger,
     get_latest_checkpoint_path, get_strategy
 )
 from utils.phoneme_utils import locate_dictionary, build_phoneme_list

--- a/basics/base_task.py
+++ b/basics/base_task.py
@@ -61,7 +61,6 @@ class BaseTask(pl.LightningModule):
     def __init__(self, *args, **kwargs):
         # dataset configs
         super().__init__(*args, **kwargs)
-        self.dataset_cls = None
         self.max_batch_frames = hparams['max_batch_frames']
         self.max_batch_size = hparams['max_batch_size']
         self.max_val_batch_frames = hparams['max_val_batch_frames']
@@ -71,23 +70,7 @@ class BaseTask(pl.LightningModule):
         if self.max_val_batch_size == -1:
             hparams['max_val_batch_size'] = self.max_val_batch_size = self.max_batch_size
 
-        self.training_sampler = None
-        self.model = None
-        self.skip_immediate_validation = False
-        self.skip_immediate_ckpt_save = False
-
-        self.valid_losses: Dict[str, Metric] = {
-            'total_loss': MeanMetric()
-        }
-        self.valid_metrics: Dict[str, Metric] = {}
-
-    ###########
-    # Training, validation and testing
-    ###########
-    def setup(self, stage):
         self.phone_encoder = self.build_phone_encoder()
-        self.train_dataset = self.dataset_cls(hparams['train_set_name'])
-        self.valid_dataset = self.dataset_cls(hparams['valid_set_name'])
         self.model = self.build_model()
         # utils.load_warp(self)
         self.unfreeze_all_params()
@@ -96,6 +79,23 @@ class BaseTask(pl.LightningModule):
         if hparams['finetune_enabled'] and get_latest_checkpoint_path(pathlib.Path(hparams['work_dir'])) is None:
             self.load_finetune_ckpt(self.load_pre_train_model())
         self.print_arch()
+
+        self.training_sampler = None
+        self.skip_immediate_validation = False
+        self.skip_immediate_ckpt_save = False
+
+        self.valid_losses: Dict[str, Metric] = {
+            'total_loss': MeanMetric()
+        }
+        self.valid_metrics: Dict[str, Metric] = {}
+        self.build_losses_and_metrics()
+
+    ###########
+    # Training, validation and testing
+    ###########
+    def setup(self, stage):
+        self.train_dataset = self.dataset_cls(hparams['train_set_name'])
+        self.valid_dataset = self.dataset_cls(hparams['valid_set_name'])
         self.num_replicas = (self.trainer.distributed_sampler_kwargs or {}).get('num_replicas', 1)
 
     def get_need_freeze_state_dict_key(self, model_state_dict) -> list:
@@ -122,7 +122,6 @@ class BaseTask(pl.LightningModule):
     def load_finetune_ckpt(
             self, state_dict
     ) -> None:
-
         adapt_shapes = hparams['finetune_strict_shapes']
         if not adapt_shapes:
             cur_model_state_dict = self.state_dict()
@@ -138,7 +137,6 @@ class BaseTask(pl.LightningModule):
         self.load_state_dict(state_dict, strict=False)
 
     def load_pre_train_model(self):
-
         pre_train_ckpt_path = hparams.get('finetune_ckpt_path')
         blacklist = hparams.get('finetune_ignored_params')
         # whitelist=hparams.get('pre_train_whitelist')

--- a/configs/acoustic.yaml
+++ b/configs/acoustic.yaml
@@ -103,6 +103,7 @@ lr_scheduler_args:
   gamma: 0.5
 max_batch_frames: 80000
 max_batch_size: 48
+dataset_size_key: 'lengths'
 val_with_vocoder: true
 val_check_interval: 2000
 num_valid_plots: 10

--- a/configs/base.yaml
+++ b/configs/base.yaml
@@ -88,8 +88,11 @@ pl_trainer_accelerator: 'auto'
 pl_trainer_devices: 'auto'
 pl_trainer_precision: '32-true'
 pl_trainer_num_nodes: 1
-pl_trainer_strategy: 'auto'
-ddp_backend: 'nccl' # choose from 'gloo', 'nccl', 'nccl_no_p2p'
+pl_trainer_strategy: 
+  name: auto
+  process_group_backend: nccl
+  find_unused_parameters: false
+nccl_p2p: true
 
 ###########
 # finetune

--- a/configs/variance.yaml
+++ b/configs/variance.yaml
@@ -106,6 +106,7 @@ lr_scheduler_args:
   gamma: 0.75
 max_batch_frames: 80000
 max_batch_size: 48
+dataset_size_key: 'lengths'
 val_check_interval: 2000
 num_valid_plots: 10
 max_updates: 288000

--- a/docs/ConfigurationSchemas.md
+++ b/docs/ConfigurationSchemas.md
@@ -658,34 +658,6 @@ string
 
 lengths
 
-### ddp_backend
-
-The distributed training backend.
-
-#### visibility
-
-all
-
-#### scope
-
-training
-
-#### customizability
-
-normal
-
-#### type
-
-str
-
-#### default
-
-nccl
-
-#### constraints
-
-Choose from 'gloo', 'nccl', 'nccl_no_p2p'. Windows platforms may use 'gloo'; Linux platforms may use 'nccl'; if Linux ddp gets stuck, use 'nccl_no_p2p'.
-
 ### dictionary
 
 Path to the word-phoneme mapping dictionary file. Training data must fully cover phonemes in the dictionary.
@@ -1982,6 +1954,30 @@ float
 
 0.06
 
+### nccl_p2p
+
+Whether to enable P2P when using NCCL as the backend. Turn it to `false` if the training process is stuck upon beginning.
+
+#### visibility
+
+all
+
+#### scope
+
+training
+
+#### customizability
+
+normal
+
+#### type
+
+bool
+
+#### default
+
+true
+
 ### num_ckpt_keep
 
 Number of newest checkpoints kept during training.
@@ -2510,9 +2506,9 @@ int
 
 1
 
-### pl_trainer_strategy
+### pl_trainer_strategy.name
 
-Strategies of the Lightning trainer behavior.
+Strategy name for the Lightning trainer.
 
 #### visibility
 

--- a/docs/ConfigurationSchemas.md
+++ b/docs/ConfigurationSchemas.md
@@ -634,6 +634,30 @@ bool
 
 true
 
+### dataset_size_key
+
+The key that indexes the binarized metadata to be used as the `sizes` when batching by size
+
+#### visibility
+
+all
+
+#### scope
+
+training
+
+#### customizability
+
+not recommended
+
+#### type
+
+string
+
+#### default
+
+lengths
+
 ### ddp_backend
 
 The distributed training backend.

--- a/docs/ConfigurationSchemas.md
+++ b/docs/ConfigurationSchemas.md
@@ -652,7 +652,7 @@ not recommended
 
 #### type
 
-string
+str
 
 #### default
 
@@ -2505,6 +2505,14 @@ int
 #### default
 
 1
+
+### pl_trainer_strategy
+
+Arguments of Lightning Strategy. Values will be used as keyword arguments when constructing the Strategy object.
+
+#### type
+
+dict
 
 ### pl_trainer_strategy.name
 

--- a/docs/ConfigurationSchemas.md
+++ b/docs/ConfigurationSchemas.md
@@ -1848,7 +1848,7 @@ training
 
 #### customizability
 
-reserved
+normal
 
 #### type
 
@@ -1872,7 +1872,7 @@ training
 
 #### customizability
 
-reserved
+normal
 
 #### type
 

--- a/modules/nsf_hifigan/env.py
+++ b/modules/nsf_hifigan/env.py
@@ -1,7 +1,30 @@
 class AttrDict(dict):
+    """A dictionary with attribute-style access. It maps attribute access to
+    the real dictionary.  """
     def __init__(self, *args, **kwargs):
-        super(AttrDict, self).__init__(*args, **kwargs)
-        self.__dict__ = self
+        dict.__init__(self, *args, **kwargs)
 
-    def __getattr__(self, item):
-        return self[item]
+    def __getstate__(self):
+        return self.__dict__.items()
+
+    def __setstate__(self, items):
+        for key, val in items:
+            self.__dict__[key] = val
+
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, dict.__repr__(self))
+
+    def __setitem__(self, key, value):
+        return super(AttrDict, self).__setitem__(key, value)
+
+    def __getitem__(self, name):
+        return super(AttrDict, self).__getitem__(name)
+
+    def __delitem__(self, name):
+        return super(AttrDict, self).__delitem__(name)
+
+    __getattr__ = __getitem__
+    __setattr__ = __setitem__
+
+    def copy(self):
+        return AttrDict(self)

--- a/preprocessing/acoustic_binarizer.py
+++ b/preprocessing/acoustic_binarizer.py
@@ -64,7 +64,7 @@ class AcousticBinarizer(BaseBinarizer):
                         'ph_seq': utterance_label['ph_seq'].split(),
                         'ph_dur': [float(x) for x in utterance_label['ph_dur'].split()],
                         'spk_id': spk_id,
-                        'spk': self.speakers[ds_id],
+                        'spk_name': self.speakers[ds_id],
                     }
                     assert len(temp_dict['ph_seq']) == len(temp_dict['ph_dur']), \
                         f'Lengths of ph_seq and ph_dur mismatch in \'{item_name}\'.'
@@ -90,7 +90,7 @@ class AcousticBinarizer(BaseBinarizer):
             'name': item_name,
             'wav_fn': meta_data['wav_fn'],
             'spk_id': meta_data['spk_id'],
-            'spk': meta_data['spk'],
+            'spk_name': meta_data['spk_name'],
             'seconds': seconds,
             'length': length,
             'mel': mel,

--- a/preprocessing/acoustic_binarizer.py
+++ b/preprocessing/acoustic_binarizer.py
@@ -56,19 +56,19 @@ class AcousticBinarizer(BaseBinarizer):
     def load_meta_data(self, raw_data_dir: pathlib.Path, ds_id, spk_id):
         meta_data_dict = {}
         if (raw_data_dir / 'transcriptions.csv').exists():
-            for utterance_label in csv.DictReader(
-                    open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf-8')
-            ):
-                item_name = utterance_label['name']
-                temp_dict = {
-                    'wav_fn': str(raw_data_dir / 'wavs' / f'{item_name}.wav'),
-                    'ph_seq': utterance_label['ph_seq'].split(),
-                    'ph_dur': [float(x) for x in utterance_label['ph_dur'].split()],
-                    'spk_id': spk_id
-                }
-                assert len(temp_dict['ph_seq']) == len(temp_dict['ph_dur']), \
-                    f'Lengths of ph_seq and ph_dur mismatch in \'{item_name}\'.'
-                meta_data_dict[f'{ds_id}:{item_name}'] = temp_dict
+            with open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf-8') as f:
+                for utterance_label in csv.DictReader(f):
+                    item_name = utterance_label['name']
+                    temp_dict = {
+                        'wav_fn': str(raw_data_dir / 'wavs' / f'{item_name}.wav'),
+                        'ph_seq': utterance_label['ph_seq'].split(),
+                        'ph_dur': [float(x) for x in utterance_label['ph_dur'].split()],
+                        'spk_id': spk_id,
+                        'spk': self.speakers[ds_id],
+                    }
+                    assert len(temp_dict['ph_seq']) == len(temp_dict['ph_dur']), \
+                        f'Lengths of ph_seq and ph_dur mismatch in \'{item_name}\'.'
+                    meta_data_dict[f'{ds_id}:{item_name}'] = temp_dict
         else:
             raise FileNotFoundError(
                 f'transcriptions.csv not found in {raw_data_dir}. '
@@ -90,6 +90,7 @@ class AcousticBinarizer(BaseBinarizer):
             'name': item_name,
             'wav_fn': meta_data['wav_fn'],
             'spk_id': meta_data['spk_id'],
+            'spk': meta_data['spk'],
             'seconds': seconds,
             'length': length,
             'mel': mel,

--- a/preprocessing/variance_binarizer.py
+++ b/preprocessing/variance_binarizer.py
@@ -122,7 +122,7 @@ class VarianceBinarizer(BaseBinarizer):
                 temp_dict = {
                     'ds_idx': item_idx,
                     'spk_id': spk_id,
-                    'spk': self.speakers[ds_id],
+                    'spk_name': self.speakers[ds_id],
                     'wav_fn': str(raw_data_dir / 'wavs' / f'{item_name}.wav'),
                     'ph_seq': require('ph_seq').split(),
                     'ph_dur': [float(x) for x in require('ph_dur').split()]
@@ -233,7 +233,7 @@ class VarianceBinarizer(BaseBinarizer):
             'name': item_name,
             'wav_fn': meta_data['wav_fn'],
             'spk_id': meta_data['spk_id'],
-            'spk': meta_data['spk'],
+            'spk_name': meta_data['spk_name'],
             'seconds': seconds,
             'length': length,
             'tokens': np.array(self.phone_encoder.encode(meta_data['ph_seq']), dtype=np.int64)

--- a/preprocessing/variance_binarizer.py
+++ b/preprocessing/variance_binarizer.py
@@ -102,51 +102,51 @@ class VarianceBinarizer(BaseBinarizer):
     def load_meta_data(self, raw_data_dir: pathlib.Path, ds_id, spk_id):
         meta_data_dict = {}
 
-        for utterance_label in csv.DictReader(
-                open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf8')
-        ):
-            utterance_label: dict
-            item_name = utterance_label['name']
-            item_idx = int(item_name.rsplit(DS_INDEX_SEP, maxsplit=1)[-1]) if DS_INDEX_SEP in item_name else 0
+        with open(raw_data_dir / 'transcriptions.csv', 'r', encoding='utf8') as f:
+            for utterance_label in csv.DictReader(f):
+                utterance_label: dict
+                item_name = utterance_label['name']
+                item_idx = int(item_name.rsplit(DS_INDEX_SEP, maxsplit=1)[-1]) if DS_INDEX_SEP in item_name else 0
 
-            def require(attr):
-                if self.prefer_ds:
-                    value = self.load_attr_from_ds(ds_id, item_name, attr, item_idx)
-                else:
-                    value = None
-                if value is None:
-                    value = utterance_label.get(attr)
-                if value is None:
-                    raise ValueError(f'Missing required attribute {attr} of item \'{item_name}\'.')
-                return value
+                def require(attr):
+                    if self.prefer_ds:
+                        value = self.load_attr_from_ds(ds_id, item_name, attr, item_idx)
+                    else:
+                        value = None
+                    if value is None:
+                        value = utterance_label.get(attr)
+                    if value is None:
+                        raise ValueError(f'Missing required attribute {attr} of item \'{item_name}\'.')
+                    return value
 
-            temp_dict = {
-                'ds_idx': item_idx,
-                'spk_id': spk_id,
-                'wav_fn': str(raw_data_dir / 'wavs' / f'{item_name}.wav'),
-                'ph_seq': require('ph_seq').split(),
-                'ph_dur': [float(x) for x in require('ph_dur').split()]
-            }
+                temp_dict = {
+                    'ds_idx': item_idx,
+                    'spk_id': spk_id,
+                    'spk': self.speakers[ds_id],
+                    'wav_fn': str(raw_data_dir / 'wavs' / f'{item_name}.wav'),
+                    'ph_seq': require('ph_seq').split(),
+                    'ph_dur': [float(x) for x in require('ph_dur').split()]
+                }
 
-            assert len(temp_dict['ph_seq']) == len(temp_dict['ph_dur']), \
-                f'Lengths of ph_seq and ph_dur mismatch in \'{item_name}\'.'
+                assert len(temp_dict['ph_seq']) == len(temp_dict['ph_dur']), \
+                    f'Lengths of ph_seq and ph_dur mismatch in \'{item_name}\'.'
 
-            if hparams['predict_dur']:
-                temp_dict['ph_num'] = [int(x) for x in require('ph_num').split()]
-                assert len(temp_dict['ph_seq']) == sum(temp_dict['ph_num']), \
-                    f'Sum of ph_num does not equal length of ph_seq in \'{item_name}\'.'
+                if hparams['predict_dur']:
+                    temp_dict['ph_num'] = [int(x) for x in require('ph_num').split()]
+                    assert len(temp_dict['ph_seq']) == sum(temp_dict['ph_num']), \
+                        f'Sum of ph_num does not equal length of ph_seq in \'{item_name}\'.'
 
-            if hparams['predict_pitch']:
-                temp_dict['note_seq'] = require('note_seq').split()
-                temp_dict['note_dur'] = [float(x) for x in require('note_dur').split()]
-                assert len(temp_dict['note_seq']) == len(temp_dict['note_dur']), \
-                    f'Lengths of note_seq and note_dur mismatch in \'{item_name}\'.'
-                assert any([note != 'rest' for note in temp_dict['note_seq']]), \
-                    f'All notes are rest in \'{item_name}\'.'
-                if hparams['use_glide_embed']:
-                    temp_dict['note_glide'] = require('note_glide').split()
+                if hparams['predict_pitch']:
+                    temp_dict['note_seq'] = require('note_seq').split()
+                    temp_dict['note_dur'] = [float(x) for x in require('note_dur').split()]
+                    assert len(temp_dict['note_seq']) == len(temp_dict['note_dur']), \
+                        f'Lengths of note_seq and note_dur mismatch in \'{item_name}\'.'
+                    assert any([note != 'rest' for note in temp_dict['note_seq']]), \
+                        f'All notes are rest in \'{item_name}\'.'
+                    if hparams['use_glide_embed']:
+                        temp_dict['note_glide'] = require('note_glide').split()
 
-            meta_data_dict[f'{ds_id}:{item_name}'] = temp_dict
+                meta_data_dict[f'{ds_id}:{item_name}'] = temp_dict
 
         self.items.update(meta_data_dict)
 
@@ -233,6 +233,7 @@ class VarianceBinarizer(BaseBinarizer):
             'name': item_name,
             'wav_fn': meta_data['wav_fn'],
             'spk_id': meta_data['spk_id'],
+            'spk': meta_data['spk'],
             'seconds': seconds,
             'length': length,
             'tokens': np.array(self.phone_encoder.encode(meta_data['ph_seq']), dtype=np.int64)

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -13,7 +13,7 @@ os.environ['TORCH_CUDNN_V8_API_ENABLED'] = '1'  # Prevent unacceptable slowdowns
 from utils.hparams import set_hparams, hparams
 
 set_hparams()
-if hparams['ddp_backend'] == 'nccl_no_p2p':
+if not hparams['nccl_p2p']:
     print("Disabling NCCL P2P")
     os.environ['NCCL_P2P_DISABLE'] = '1'
 

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -14,7 +14,7 @@ from modules.losses.diff_loss import DiffusionNoiseLoss
 from modules.toplevel import DiffSingerAcoustic, ShallowDiffusionOutput
 from modules.vocoders.registry import get_vocoder_cls
 from utils.hparams import hparams
-from utils.plot import spec_to_figure, curve_to_figure
+from utils.plot import spec_to_figure
 
 matplotlib.use('Agg')
 
@@ -34,6 +34,8 @@ class AcousticDataset(BaseDataset):
 
     def collater(self, samples):
         batch = super().collater(samples)
+        if batch['size'] == 0:
+            return batch
 
         tokens = utils.collate_nd([s['tokens'] for s in samples], 0)
         f0 = utils.collate_nd([s['f0'] for s in samples], 0.0)
@@ -76,6 +78,7 @@ class AcousticTask(BaseTask):
             self.required_variances.append('energy')
         if hparams.get('use_breathiness_embed', False):
             self.required_variances.append('breathiness')
+        self.build_losses_and_metrics()
 
     def build_model(self):
         return DiffSingerAcoustic(
@@ -88,7 +91,9 @@ class AcousticTask(BaseTask):
         if self.use_shallow_diffusion:
             self.aux_mel_loss = build_aux_loss(self.shallow_args['aux_decoder_arch'])
             self.lambda_aux_mel_loss = hparams['lambda_aux_mel_loss']
+            self.register_validation_loss('aux_mel_loss')
         self.mel_loss = DiffusionNoiseLoss(loss_type=hparams['diff_loss_type'])
+        self.register_validation_loss('mel_loss')
 
     def run_model(self, sample, infer=False):
         txt_tokens = sample['tokens']  # [B, T_ph]
@@ -140,57 +145,63 @@ class AcousticTask(BaseTask):
 
     def _validation_step(self, sample, batch_idx):
         losses = self.run_model(sample, infer=False)
-
-        if batch_idx < hparams['num_valid_plots'] \
-                and (self.trainer.distributed_sampler_kwargs or {}).get('rank', 0) == 0:
+        if sample['size'] > 0 and min(sample['indices']) < hparams['num_valid_plots']:
             mel_out: ShallowDiffusionOutput = self.run_model(sample, infer=True)
-
-            if self.use_vocoder:
-                self.plot_wav(
-                    batch_idx, gt_mel=sample['mel'],
-                    aux_mel=mel_out.aux_out, diff_mel=mel_out.diff_out,
-                    f0=sample['f0']
-                )
-            if mel_out.aux_out is not None:
-                self.plot_mel(batch_idx, sample['mel'], mel_out.aux_out, name=f'auxmel_{batch_idx}')
-            if mel_out.diff_out is not None:
-                self.plot_mel(batch_idx, sample['mel'], mel_out.diff_out, name=f'diffmel_{batch_idx}')
-
+            for i in range(len(sample['indices'])):
+                data_idx = sample['indices'][i]
+                if data_idx < hparams['num_valid_plots']:
+                    if self.use_vocoder:
+                        self.plot_wav(
+                            data_idx, sample['mel'][i],
+                            mel_out.aux_out[i], mel_out.diff_out[i],
+                            sample['f0'][i]
+                        )
+                    self.plot_mel(data_idx, sample['mel'][i], mel_out.aux_out[i], 'auxmel')
+                    self.plot_mel(data_idx, sample['mel'][i], mel_out.diff_out[i], 'diffmel')
         return losses, sample['size']
+
 
     ############
     # validation plots
     ############
-    def plot_wav(self, batch_idx, gt_mel, aux_mel=None, diff_mel=None, f0=None):
-        gt_mel = gt_mel[0].cpu().numpy()
+    def plot_wav(self, data_idx, gt_mel, aux_mel, diff_mel, f0):
+        f0_len = self.valid_dataset.metadata['f0'][data_idx]
+        mel_len = self.valid_dataset.metadata['mel'][data_idx]
+        gt_mel = gt_mel[:mel_len].unsqueeze(0)
         if aux_mel is not None:
-            aux_mel = aux_mel[0].cpu().numpy()
+            aux_mel = aux_mel[:mel_len].unsqueeze(0)
         if diff_mel is not None:
-            diff_mel = diff_mel[0].cpu().numpy()
-        f0 = f0[0].cpu().numpy()
-        if batch_idx not in self.logged_gt_wav:
-            gt_wav = self.vocoder.spec2wav(gt_mel, f0=f0)
-            self.logger.experiment.add_audio(f'gt_{batch_idx}', gt_wav, sample_rate=hparams['audio_sample_rate'],
-                                             global_step=self.global_step)
-            self.logged_gt_wav.add(batch_idx)
+            diff_mel = diff_mel[:mel_len].unsqueeze(0)
+        f0 = f0[:f0_len].unsqueeze(0)
+        if data_idx not in self.logged_gt_wav:
+            gt_wav = self.vocoder.spec2wav_torch(gt_mel, f0=f0)
+            self.logger.all_rank_experiment.add_audio(
+                f'gt_{data_idx}', gt_wav,
+                sample_rate=hparams['audio_sample_rate'],
+                global_step=self.global_step
+            )
+            self.logged_gt_wav.add(data_idx)
         if aux_mel is not None:
-            aux_wav = self.vocoder.spec2wav(aux_mel, f0=f0)
-            self.logger.experiment.add_audio(f'aux_{batch_idx}', aux_wav, sample_rate=hparams['audio_sample_rate'],
-                                             global_step=self.global_step)
+            aux_wav = self.vocoder.spec2wav_torch(aux_mel, f0=f0)
+            self.logger.all_rank_experiment.add_audio(
+                f'aux_{data_idx}', aux_wav,
+                sample_rate=hparams['audio_sample_rate'],
+                global_step=self.global_step
+            )
         if diff_mel is not None:
-            diff_wav = self.vocoder.spec2wav(diff_mel, f0=f0)
-            self.logger.experiment.add_audio(f'diff_{batch_idx}', diff_wav, sample_rate=hparams['audio_sample_rate'],
-                                             global_step=self.global_step)
+            diff_wav = self.vocoder.spec2wav_torch(diff_mel, f0=f0)
+            self.logger.all_rank_experiment.add_audio(
+                f'diff_{data_idx}', diff_wav,
+                sample_rate=hparams['audio_sample_rate'],
+                global_step=self.global_step
+            )
 
-    def plot_mel(self, batch_idx, spec, spec_out, name=None):
-        name = f'mel_{batch_idx}' if name is None else name
+    def plot_mel(self, data_idx, gt_spec, out_spec, name_prefix='mel'):
         vmin = hparams['mel_vmin']
         vmax = hparams['mel_vmax']
-        spec_cat = torch.cat([(spec_out - spec).abs() + vmin, spec, spec_out], -1)
-        self.logger.experiment.add_figure(name, spec_to_figure(spec_cat[0], vmin, vmax), self.global_step)
-
-    def plot_curve(self, batch_idx, gt_curve, pred_curve, curve_name='curve'):
-        name = f'{curve_name}_{batch_idx}'
-        gt_curve = gt_curve[0].cpu().numpy()
-        pred_curve = pred_curve[0].cpu().numpy()
-        self.logger.experiment.add_figure(name, curve_to_figure(gt_curve, pred_curve), self.global_step)
+        mel_len = self.valid_dataset.metadata['mel'][data_idx]
+        spec_cat = torch.cat([(out_spec - gt_spec).abs() + vmin, gt_spec, out_spec], -1)
+        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        self.logger.all_rank_experiment.add_figure(f'{name_prefix}_{data_idx}',  spec_to_figure(
+            spec_cat[:mel_len], vmin, vmax, title_text
+        ), global_step=self.global_step)

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -61,6 +61,7 @@ class AcousticDataset(BaseDataset):
 
 class AcousticTask(BaseTask):
     def __init__(self):
+        super().__init__()
         self.dataset_cls = AcousticDataset
         self.use_shallow_diffusion = hparams['use_shallow_diffusion']
         if self.use_shallow_diffusion:
@@ -77,9 +78,9 @@ class AcousticTask(BaseTask):
             self.required_variances.append('energy')
         if hparams.get('use_breathiness_embed', False):
             self.required_variances.append('breathiness')
-        super().__init__()
+        super()._finish_init()
 
-    def build_model(self):
+    def _build_model(self):
         return DiffSingerAcoustic(
             vocab_size=len(self.phone_encoder),
             out_dims=hparams['audio_num_mel_bins']

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -61,7 +61,6 @@ class AcousticDataset(BaseDataset):
 
 class AcousticTask(BaseTask):
     def __init__(self):
-        super().__init__()
         self.dataset_cls = AcousticDataset
         self.use_shallow_diffusion = hparams['use_shallow_diffusion']
         if self.use_shallow_diffusion:
@@ -78,7 +77,7 @@ class AcousticTask(BaseTask):
             self.required_variances.append('energy')
         if hparams.get('use_breathiness_embed', False):
             self.required_variances.append('breathiness')
-        self.build_losses_and_metrics()
+        super().__init__()
 
     def build_model(self):
         return DiffSingerAcoustic(
@@ -156,8 +155,10 @@ class AcousticTask(BaseTask):
                             mel_out.aux_out[i], mel_out.diff_out[i],
                             sample['f0'][i]
                         )
-                    self.plot_mel(data_idx, sample['mel'][i], mel_out.aux_out[i], 'auxmel')
-                    self.plot_mel(data_idx, sample['mel'][i], mel_out.diff_out[i], 'diffmel')
+                    if mel_out.aux_out is not None:
+                        self.plot_mel(data_idx, sample['mel'][i], mel_out.aux_out[i], 'auxmel')
+                    if mel_out.diff_out is not None:
+                        self.plot_mel(data_idx, sample['mel'][i], mel_out.diff_out[i], 'diffmel')
         return losses, sample['size']
 
 

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -20,8 +20,8 @@ matplotlib.use('Agg')
 
 
 class AcousticDataset(BaseDataset):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, prefix, preload=False):
+        super(AcousticDataset, self).__init__(prefix, hparams['dataset_size_key'], preload)
         self.required_variances = {}  # key: variance name, value: padding value
         if hparams.get('use_energy_embed', False):
             self.required_variances['energy'] = 0.0

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -204,7 +204,7 @@ class AcousticTask(BaseTask):
         vmax = hparams['mel_vmax']
         mel_len = self.valid_dataset.metadata['mel'][data_idx]
         spec_cat = torch.cat([(out_spec - gt_spec).abs() + vmin, gt_spec, out_spec], -1)
-        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        title_text = f"{self.valid_dataset.metadata['spk_names'][data_idx]} - {self.valid_dataset.metadata['names'][data_idx]}"
         self.logger.all_rank_experiment.add_figure(f'{name_prefix}_{data_idx}',  spec_to_figure(
             spec_cat[:mel_len], vmin, vmax, title_text
         ), global_step=self.global_step)

--- a/training/acoustic_task.py
+++ b/training/acoustic_task.py
@@ -153,7 +153,8 @@ class AcousticTask(BaseTask):
                     if self.use_vocoder:
                         self.plot_wav(
                             data_idx, sample['mel'][i],
-                            mel_out.aux_out[i], mel_out.diff_out[i],
+                            mel_out.aux_out[i] if mel_out.aux_out is not None else None,
+                            mel_out.diff_out[i],
                             sample['f0'][i]
                         )
                     if mel_out.aux_out is not None:

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -74,6 +74,7 @@ def random_retake_masks(b, t, device):
 
 class VarianceTask(BaseTask):
     def __init__(self):
+        super().__init__()
         self.dataset_cls = VarianceDataset
 
         self.use_spk_id = hparams['use_spk_id']
@@ -95,9 +96,9 @@ class VarianceTask(BaseTask):
             self.variance_prediction_list.append('breathiness')
         self.predict_variances = len(self.variance_prediction_list) > 0
         self.lambda_var_loss = hparams['lambda_var_loss']
-        super().__init__()
+        super()._finish_init()
 
-    def build_model(self):
+    def _build_model(self):
         return DiffSingerVariance(
             vocab_size=len(self.phone_encoder),
         )

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -20,8 +20,8 @@ matplotlib.use('Agg')
 
 
 class VarianceDataset(BaseDataset):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, prefix, preload=False):
+        super(VarianceDataset, self).__init__(prefix, hparams['dataset_size_key'], preload)
         need_energy = hparams['predict_energy']
         need_breathiness = hparams['predict_breathiness']
         self.predict_variances = need_energy or need_breathiness

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -74,7 +74,6 @@ def random_retake_masks(b, t, device):
 
 class VarianceTask(BaseTask):
     def __init__(self):
-        super().__init__()
         self.dataset_cls = VarianceDataset
 
         self.use_spk_id = hparams['use_spk_id']
@@ -96,7 +95,7 @@ class VarianceTask(BaseTask):
             self.variance_prediction_list.append('breathiness')
         self.predict_variances = len(self.variance_prediction_list) > 0
         self.lambda_var_loss = hparams['lambda_var_loss']
-        self.build_losses_and_metrics()
+        super().__init__()
 
     def build_model(self):
         return DiffSingerVariance(

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -252,7 +252,7 @@ class VarianceTask(BaseTask):
         gt_dur = gt_dur[0].cpu().numpy()
         pred_dur = pred_dur[0].cpu().numpy()
         txt = self.phone_encoder.decode(txt[0].cpu().numpy()).split()
-        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        title_text = f"{self.valid_dataset.metadata['spk_names'][data_idx]} - {self.valid_dataset.metadata['names'][data_idx]}"
         self.logger.all_rank_experiment.add_figure(f'dur_{data_idx}', dur_to_figure(
             gt_dur, pred_dur, txt, title_text
         ), self.global_step)
@@ -263,7 +263,7 @@ class VarianceTask(BaseTask):
         note_midi = note_midi[0].cpu().numpy()
         note_dur = note_dur[0].cpu().numpy()
         note_rest = note_rest[0].cpu().numpy()
-        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        title_text = f"{self.valid_dataset.metadata['spk_names'][data_idx]} - {self.valid_dataset.metadata['names'][data_idx]}"
         self.logger.all_rank_experiment.add_figure(f'pitch_{data_idx}', pitch_note_to_figure(
             gt_pitch, pred_pitch, note_midi, note_dur, note_rest, title_text
         ), self.global_step)
@@ -273,7 +273,7 @@ class VarianceTask(BaseTask):
         pred_curve = pred_curve[0].cpu().numpy()
         if base_curve is not None:
             base_curve = base_curve[0].cpu().numpy()
-        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        title_text = f"{self.valid_dataset.metadata['spk_names'][data_idx]} - {self.valid_dataset.metadata['names'][data_idx]}"
         self.logger.all_rank_experiment.add_figure(f'{curve_name}_{data_idx}', curve_to_figure(
             gt_curve, pred_curve, base_curve, grid=grid, title=title_text
         ), self.global_step)

--- a/training/variance_task.py
+++ b/training/variance_task.py
@@ -28,6 +28,8 @@ class VarianceDataset(BaseDataset):
 
     def collater(self, samples):
         batch = super().collater(samples)
+        if batch['size'] == 0:
+            return batch
 
         tokens = utils.collate_nd([s['tokens'] for s in samples], 0)
         ph_dur = utils.collate_nd([s['ph_dur'] for s in samples], 0)
@@ -94,6 +96,7 @@ class VarianceTask(BaseTask):
             self.variance_prediction_list.append('breathiness')
         self.predict_variances = len(self.variance_prediction_list) > 0
         self.lambda_var_loss = hparams['lambda_var_loss']
+        self.build_losses_and_metrics()
 
     def build_model(self):
         return DiffSingerVariance(
@@ -111,17 +114,20 @@ class VarianceTask(BaseTask):
                 lambda_wdur=dur_hparams['lambda_wdur_loss'],
                 lambda_sdur=dur_hparams['lambda_sdur_loss']
             )
-            self.register_metric('rhythm_corr', RhythmCorrectness(tolerance=0.05))
-            self.register_metric('ph_dur_acc', PhonemeDurationAccuracy(tolerance=0.2))
+            self.register_validation_loss('dur_loss')
+            self.register_validation_metric('rhythm_corr', RhythmCorrectness(tolerance=0.05))
+            self.register_validation_metric('ph_dur_acc', PhonemeDurationAccuracy(tolerance=0.2))
         if self.predict_pitch:
             self.pitch_loss = DiffusionNoiseLoss(
                 loss_type=hparams['diff_loss_type'],
             )
-            self.register_metric('pitch_acc', RawCurveAccuracy(tolerance=0.5))
+            self.register_validation_loss('pitch_loss')
+            self.register_validation_metric('pitch_acc', RawCurveAccuracy(tolerance=0.5))
         if self.predict_variances:
             self.var_loss = DiffusionNoiseLoss(
                 loss_type=hparams['diff_loss_type'],
             )
+            self.register_validation_loss('var_loss')
 
     def run_model(self, sample, infer=False):
         spk_ids = sample['spk_ids'] if self.use_spk_id else None  # [B,]
@@ -191,74 +197,83 @@ class VarianceTask(BaseTask):
 
     def _validation_step(self, sample, batch_idx):
         losses = self.run_model(sample, infer=False)
-
-        if batch_idx < hparams['num_valid_plots'] \
-                and (self.trainer.distributed_sampler_kwargs or {}).get('rank', 0) == 0:
-            dur_pred, pitch_pred, variances_pred = self.run_model(sample, infer=True)
-            if dur_pred is not None:
-                tokens = sample['tokens']
-                dur_gt = sample['ph_dur']
-                ph2word = sample['ph2word']
-                mask = tokens != 0
-                self.rhythm_corr.update(
-                    pdur_pred=dur_pred, pdur_target=dur_gt, ph2word=ph2word, mask=mask
-                )
-                self.ph_dur_acc.update(
-                    pdur_pred=dur_pred, pdur_target=dur_gt, ph2word=ph2word, mask=mask
-                )
-                self.plot_dur(batch_idx, dur_gt, dur_pred, txt=tokens)
-            if pitch_pred is not None:
-                pred_pitch = sample['base_pitch'] + pitch_pred
-                gt_pitch = sample['pitch']
-                mask = (sample['mel2ph'] > 0) & ~sample['uv']
-                self.pitch_acc.update(pred=pred_pitch, target=gt_pitch, mask=mask)
-                self.plot_pitch(
-                    batch_idx,
-                    gt_pitch=gt_pitch,
-                    pred_pitch=pred_pitch,
-                    note_midi=sample['note_midi'],
-                    note_dur=sample['note_dur'],
-                    note_rest=sample['note_rest']
-                )
-            for name in self.variance_prediction_list:
-                variance = sample[name]
-                variance_pred = variances_pred[name]
-                self.plot_curve(
-                    batch_idx,
-                    gt_curve=variance,
-                    pred_curve=variance_pred,
-                    curve_name=name
-                )
-
+        if min(sample['indices']) < hparams['num_valid_plots']:
+            def sample_get(key, idx, abs_idx):
+                return sample[key][idx][:self.valid_dataset.metadata[key][abs_idx]].unsqueeze(0)
+            dur_preds, pitch_preds, variances_preds = self.run_model(sample, infer=True)
+            for i in range(len(sample['indices'])):
+                data_idx = sample['indices'][i]
+                if data_idx < hparams['num_valid_plots']:
+                    if dur_preds is not None:
+                        dur_len = self.valid_dataset.metadata['ph_dur'][data_idx]
+                        tokens = sample_get('tokens', i, data_idx)
+                        gt_dur = sample_get('ph_dur', i, data_idx)
+                        pred_dur = dur_preds[i][:dur_len].unsqueeze(0)
+                        ph2word = sample_get('ph2word', i, data_idx)
+                        mask = tokens != 0
+                        self.valid_metrics['rhythm_corr'].update(
+                            pdur_pred=pred_dur, pdur_target=gt_dur, ph2word=ph2word, mask=mask
+                        )
+                        self.valid_metrics['ph_dur_acc'].update(
+                            pdur_pred=pred_dur, pdur_target=gt_dur, ph2word=ph2word, mask=mask
+                        )
+                        self.plot_dur(data_idx, gt_dur, pred_dur, tokens)
+                    if pitch_preds is not None:
+                        pitch_len = self.valid_dataset.metadata['pitch'][data_idx]
+                        pred_pitch = sample_get('base_pitch', i, data_idx) + pitch_preds[i][:pitch_len].unsqueeze(0)
+                        gt_pitch = sample_get('pitch', i, data_idx)
+                        mask = (sample_get('mel2ph', i, data_idx) > 0) & ~sample_get('uv', i, data_idx)
+                        self.valid_metrics['pitch_acc'].update(pred=pred_pitch, target=gt_pitch, mask=mask)
+                        self.plot_pitch(
+                            data_idx,
+                            gt_pitch=gt_pitch,
+                            pred_pitch=pred_pitch,
+                            note_midi=sample_get('note_midi', i, data_idx),
+                            note_dur=sample_get('note_dur', i, data_idx),
+                            note_rest=sample_get('note_rest', i, data_idx)
+                        )
+                    for name in self.variance_prediction_list:
+                        variance_len = self.valid_dataset.metadata[name][data_idx]
+                        gt_variances = sample[name][i][:variance_len].unsqueeze(0)
+                        pred_variances = variances_preds[name][i][:variance_len].unsqueeze(0)
+                        self.plot_curve(
+                            data_idx,
+                            gt_curve=gt_variances,
+                            pred_curve=pred_variances,
+                            curve_name=name
+                        )
         return losses, sample['size']
+
 
     ############
     # validation plots
     ############
-    def plot_dur(self, batch_idx, gt_dur, pred_dur, txt=None):
-        name = f'dur_{batch_idx}'
+    def plot_dur(self, data_idx, gt_dur, pred_dur, txt=None):
         gt_dur = gt_dur[0].cpu().numpy()
         pred_dur = pred_dur[0].cpu().numpy()
         txt = self.phone_encoder.decode(txt[0].cpu().numpy()).split()
-        self.logger.experiment.add_figure(name, dur_to_figure(gt_dur, pred_dur, txt), self.global_step)
+        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        self.logger.all_rank_experiment.add_figure(f'dur_{data_idx}', dur_to_figure(
+            gt_dur, pred_dur, txt, title_text
+        ), self.global_step)
 
-    def plot_pitch(self, batch_idx, gt_pitch, pred_pitch, note_midi, note_dur, note_rest):
-        name = f'pitch_{batch_idx}'
+    def plot_pitch(self, data_idx, gt_pitch, pred_pitch, note_midi, note_dur, note_rest):
         gt_pitch = gt_pitch[0].cpu().numpy()
         pred_pitch = pred_pitch[0].cpu().numpy()
         note_midi = note_midi[0].cpu().numpy()
         note_dur = note_dur[0].cpu().numpy()
         note_rest = note_rest[0].cpu().numpy()
-        self.logger.experiment.add_figure(name, pitch_note_to_figure(
-            gt_pitch, pred_pitch, note_midi, note_dur, note_rest
+        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        self.logger.all_rank_experiment.add_figure(f'pitch_{data_idx}', pitch_note_to_figure(
+            gt_pitch, pred_pitch, note_midi, note_dur, note_rest, title_text
         ), self.global_step)
 
-    def plot_curve(self, batch_idx, gt_curve, pred_curve, base_curve=None, grid=None, curve_name='curve'):
-        name = f'{curve_name}_{batch_idx}'
+    def plot_curve(self, data_idx, gt_curve, pred_curve, base_curve=None, grid=None, curve_name='curve'):
         gt_curve = gt_curve[0].cpu().numpy()
         pred_curve = pred_curve[0].cpu().numpy()
         if base_curve is not None:
             base_curve = base_curve[0].cpu().numpy()
-        self.logger.experiment.add_figure(name, curve_to_figure(
-            gt_curve, pred_curve, base_curve, grid=grid
+        title_text = f"{self.valid_dataset.metadata['spk'][data_idx]} - {self.valid_dataset.metadata['name'][data_idx]}"
+        self.logger.all_rank_experiment.add_figure(f'{curve_name}_{data_idx}', curve_to_figure(
+            gt_curve, pred_curve, base_curve, grid=grid, title=title_text
         ), self.global_step)

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -4,16 +4,17 @@ import torch
 from matplotlib.ticker import MultipleLocator
 
 
-def spec_to_figure(spec, vmin=None, vmax=None):
+def spec_to_figure(spec, vmin=None, vmax=None, title=''):
     if isinstance(spec, torch.Tensor):
         spec = spec.cpu().numpy()
     fig = plt.figure(figsize=(12, 9))
     plt.pcolor(spec.T, vmin=vmin, vmax=vmax)
+    plt.title(title, fontsize=22)
     plt.tight_layout()
     return fig
 
 
-def dur_to_figure(dur_gt, dur_pred, txt):
+def dur_to_figure(dur_gt, dur_pred, txt, title=''):
     if isinstance(dur_gt, torch.Tensor):
         dur_gt = dur_gt.cpu().numpy()
     if isinstance(dur_pred, torch.Tensor):
@@ -35,12 +36,13 @@ def dur_to_figure(dur_gt, dur_pred, txt):
         plt.plot([dur_pred[i], dur_gt[i]], [12, 10], color='black', linewidth=2, linestyle=':')
     plt.yticks([])
     plt.xlim(0, max(dur_pred[-1], dur_gt[-1]))
-    fig.legend()
-    fig.tight_layout()
+    plt.legend()
+    plt.title(title, fontsize=22)
+    plt.tight_layout()
     return fig
 
 
-def pitch_note_to_figure(pitch_gt, pitch_pred=None, note_midi=None, note_dur=None, note_rest=None):
+def pitch_note_to_figure(pitch_gt, pitch_pred=None, note_midi=None, note_dur=None, note_rest=None, title=''):
     if isinstance(pitch_gt, torch.Tensor):
         pitch_gt = pitch_gt.cpu().numpy()
     if isinstance(pitch_pred, torch.Tensor):
@@ -51,7 +53,8 @@ def pitch_note_to_figure(pitch_gt, pitch_pred=None, note_midi=None, note_dur=Non
         note_dur = note_dur.cpu().numpy()
     if isinstance(note_rest, torch.Tensor):
         note_rest = note_rest.cpu().numpy()
-    fig = plt.figure()
+    width = max(12, min(24, len(pitch_gt) // 200))
+    fig = plt.figure(figsize=(width, 8))
     if note_midi is not None and note_dur is not None:
         note_dur_acc = np.cumsum(note_dur)
         if note_rest is None:
@@ -73,18 +76,20 @@ def pitch_note_to_figure(pitch_gt, pitch_pred=None, note_midi=None, note_dur=Non
     plt.gca().yaxis.set_major_locator(MultipleLocator(1))
     plt.grid(axis='y')
     plt.legend()
+    plt.title(title, fontsize=22)
     plt.tight_layout()
     return fig
 
 
-def curve_to_figure(curve_gt, curve_pred=None, curve_base=None, grid=None):
+def curve_to_figure(curve_gt, curve_pred=None, curve_base=None, grid=None, title=''):
     if isinstance(curve_gt, torch.Tensor):
         curve_gt = curve_gt.cpu().numpy()
     if isinstance(curve_pred, torch.Tensor):
         curve_pred = curve_pred.cpu().numpy()
     if isinstance(curve_base, torch.Tensor):
         curve_base = curve_base.cpu().numpy()
-    fig = plt.figure()
+    width = max(12, min(24, len(curve_gt) // 200))
+    fig = plt.figure(figsize=(width, 8))
     if curve_base is not None:
         plt.plot(curve_base, color='g', label='base')
     plt.plot(curve_gt, color='b', label='gt')
@@ -94,6 +99,7 @@ def curve_to_figure(curve_gt, curve_pred=None, curve_base=None, grid=None):
         plt.gca().yaxis.set_major_locator(MultipleLocator(grid))
     plt.grid(axis='y')
     plt.legend()
+    plt.title(title, fontsize=22)
     plt.tight_layout()
     return fig
 


### PR DESCRIPTION
1. Multi-node and batched validation
    1. Binarizer changes:
        1. Split train/valid set now preserves the text prefix order specified in config.
        2. Record all ndarray's first dimension into metadata (pickle).
        3. Also print duration for each speaker separately.
        4. File handle is closed in `load_meta_data`.
    2. Task code changes: 
        1. All devices participate in validation. And diffusion process accepts a batch of inputs.
        2. Custom DsTensorBoardLogger to support logging audio and images from multiple processes.
    3. Plot changes: Added `figsize` for curves and pitch plots. Added `title` ("spk - item name")
3. Multi-device strategy selection: Much easier, does not poke PL internal logic but delegates to its registry. Using `name`, one could specify all available strategies, and pass other key-value pairs as kwargs. To disable NCCL P2P, now use a new option called `nccl_p2p` (defaults to `true`).
4. Changes due to side-effects and future considerations:
    1. Dataset now admits `size_key` to specify other "sizes" from metadata for sorting samples.
    2. Dataset now admits `preload` to load all samples into memory (for TPU).
    3. DsBatchSampler is now unified as the only sampler. Several bug fixes on unwanted randomness, and correctly deals with an insufficient number of samples.
    4. Dataset get_item and collator return the indices of the item for metadata retrieval.
    5. Moved fine-tune related logic to build model.
    6. Removed dynamic validation loss creation in validation step, hoisted to the __init__ function and conformed validation metrics to the same place.

---

## Notes

1. Even though DeepSpeed is now supported, the checkpoint produced is not in the usual format. Please use it at your own discretion.
2. FSDP does not support gradient clipping by norm.
3. This PR does require a re-binarization of the datasets.