### PR TITLE
Fix D4C waveform decompositioning threshold (improves sound quality of variance models)

### DIFF
--- a/utils/binarizer_utils.py
+++ b/utils/binarizer_utils.py
@@ -150,7 +150,7 @@ class DecomposedWaveform:
         t = np.arange(0, wav_frames) * time_step
         self._f0_world = f0
         self._sp = pw.cheaptrick(x, f0, t, samplerate, fft_size=fft_size)  # extract smoothed spectrogram
-        self._ap = pw.d4c(x, f0, t, samplerate, fft_size=fft_size)  # extract aperiodicity
+        self._ap = pw.d4c(x, f0, t, samplerate, fft_size=fft_size, threshold=0.25)  # extract aperiodicity
 
     def _kth_harmonic(self, k: int) -> np.ndarray:
         """


### PR DESCRIPTION
Hello all,

Recently, users from the DiffSinger community have been experimenting with lowering the threshold of the D4C waveform decompositioning step as found in ``binarizer_utils.py``. The default setting for this is quite high, which can cause the following issues in models using variance parameters (tension and voicing in particular):
- Decreased audio quality. I myself had trained one model with the tension parameter enabled, and one without. The tension model had a not insignificant reduction in audio quality, which was not present in the model that did not use it. I had trained both the acoustic and variance models to their maximum steps, but the sound quality never improved.
- Devoicing of vowel sounds, especially when tension and voicing are trained together. With the current default settings, oftentimes vowels tend to be incorrectly recognized as being unvoiced sounds, which causes very strange gaps on long notes, reducing the quality of the model even more.

I've set the current threshold value at 0.25; there have been suggestions from the community to put an even lower value, though I have not tested that myself. The above-mentioned value has already significantly improved the quality of my latest model, which does support the tension parameter. This improvement in quality so far seems to be consistent across the board, with multiple positive reports from users so far. This is why I think it's a good idea that a lower threshold becomes the new default during waveform decomposition.

Initial findings were done by @UtaUtaUtau, who had this to say about it:

> The D4C step in the waveform decomposition class could be prone to devoicing vowels because the default threshold is pretty high. I would know from experience with developing a WORLD-based UTAU resampler, and a few voicebanks get this issue because of that high threshold. I'd recommend passing ``threshold=0.25`` in it as I found that value pretty decent at avoiding accidental vowel devoicing, although I didn't do any rigorous testing for that threshold. I'm just pointing it out because WORLD might react differently from actual singing samples versus UTAU recording samples... 

Regards,

Lotte V