### PR TITLE
Mode 'parallel' for EncSALayer to speed up infer on ONNX

### DIFF
--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -190,4 +190,3 @@ class EncSALayer(nn.Module):
         x = x * (1 - encoder_padding_mask.float()).transpose(0, 1)[..., None]
         
         return x
-


### PR DESCRIPTION
![图片](https://github.com/openvpi/DiffSinger/assets/97896816/14e5541a-5b5d-4bd5-b2c4-3bcfb07be4d0)

'transformer-parallel' is widely used in GPT-J-6B and has been proven to have the same effect as traditional transformer. 
It can be simplified as:
![图片](https://github.com/openvpi/DiffSinger/assets/97896816/26b4c41a-4f26-4871-837b-f615631ad70f)

This saves a skip link and a LayerNorm.This can bring a slight improvement in training speed on Diffsinger.

After experimentation, this modification has shown a more significant improvement on ONNX.
The following are the experimental parameters and results. The benchmark was performed using `infer_acoustic.py`, and the backbone of the model used lynxnet, without using shallow diffusion.
```
run_parallel
...20/20 [00:20<00:00,  1.00s/it]
run_series
...20/20 [00:23<00:00,  1.15s/it]

run_parallel
...20/20 [00:20<00:00,  1.01s/it]
run_series
...20/20 [00:22<00:00,  1.13s/it]

run_parallel
...20/20 [00:21<00:00,  1.07s/it]
run_series
...20/20 [00:23<00:00,  1.17s/it]

run_parallel
...20/20 [00:20<00:00,  1.03s/it]
run_series
...20/20 [00:22<00:00,  1.13s/it]

run_parallel
...20/20 [00:20<00:00,  1.04s/it]
run_series
...20/20 [00:23<00:00,  1.16s/it]
```

On average, the inference speed has increased by 8%.
This change has been applied to yousaV1.42ReFlow and there have been no reports of any issues yet.