### PR TITLE
Support exporting user-defined vocoder package names in dsconfig.yaml

### DIFF
--- a/deployment/exporters/acoustic_exporter.py
+++ b/deployment/exporters/acoustic_exporter.py
@@ -122,7 +122,7 @@ class DiffSingerAcousticExporter(BaseExporter):
             'phonemes': f'{self.model_name}.phonemes.txt',
             'acoustic': f'{model_name}.onnx',
             'hidden_size': hparams['hidden_size'],
-            'vocoder': 'nsf_hifigan_44.1k_hop512_128bin_2024.02',
+            'vocoder': hparams['vocoder_ckpt'].split("/")[-2],
         }
         # multi-speaker
         if len(self.export_spk) > 0:


### PR DESCRIPTION
In the current version, the 'vocoder' field in the exported dsconfig.yaml file is hardcoded. When users prefer to use a different vocoder as the default, they need to manually edit the dsconfig file for it to take effect.
This PR will attempt to directly read the folder name of the vocoder checkpoints and use it as the vocoder field in the dsconfig file.