### PR TITLE
Lynxnet outnorm

### DIFF
--- a/modules/aux_decoder/LYNXNetDecoder.py
+++ b/modules/aux_decoder/LYNXNetDecoder.py
@@ -69,8 +69,9 @@ class LYNXNetDecoder(nn.Module):
         x = x.transpose(1, 2)
         for layer in self.encoder_layers:
             x = layer(x)
-        x = x.transpose(1, 2)
         x = self.norm(x)
+        x = x.transpose(1, 2)
+        
         x = self.output_projection(x)
         x = x.transpose(1, 2)
         

--- a/modules/aux_decoder/LYNXNetDecoder.py
+++ b/modules/aux_decoder/LYNXNetDecoder.py
@@ -51,11 +51,6 @@ class LYNXNetDecoder(nn.Module):
         )
         self.norm = nn.LayerNorm(num_channels)
         self.output_projection = nn.Conv1d(num_channels, out_dims, kernel_size=1)
-        # self.output_projection = nn.Sequential(
-            # nn.Conv1d(num_channels, num_channels * 4, kernel_size=1),
-            # nn.GELU(),
-            # nn.Conv1d(num_channels * 4, out_dims, kernel_size=1),
-        # )
 
     def forward(self, x, infer=False):
         """

--- a/modules/aux_decoder/LYNXNetDecoder.py
+++ b/modules/aux_decoder/LYNXNetDecoder.py
@@ -50,12 +50,12 @@ class LYNXNetDecoder(nn.Module):
                     dropout=dropout_rate) for _ in range(num_layers)
         )
         self.norm = nn.LayerNorm(num_channels)
-        # self.output_projection = nn.Conv1d(num_channels, out_dims, kernel_size=1)
-        self.output_projection = nn.Sequential(
-            nn.Conv1d(num_channels, num_channels * 4, kernel_size=1),
-            nn.GELU(),
-            nn.Conv1d(num_channels * 4, out_dims, kernel_size=1),
-        )
+        self.output_projection = nn.Conv1d(num_channels, out_dims, kernel_size=1)
+        # self.output_projection = nn.Sequential(
+            # nn.Conv1d(num_channels, num_channels * 4, kernel_size=1),
+            # nn.GELU(),
+            # nn.Conv1d(num_channels * 4, out_dims, kernel_size=1),
+        # )
 
     def forward(self, x, infer=False):
         """

--- a/modules/backbones/LYNXNet.py
+++ b/modules/backbones/LYNXNet.py
@@ -139,13 +139,6 @@ class LYNXNet(nn.Module):
         self.norm = nn.LayerNorm(n_chans)
         self.output_projection = nn.Conv1d(n_chans, in_dims * n_feats, kernel_size=1)
         nn.init.zeros_(self.output_projection.weight)
-        # _ = nn.Conv1d(n_chans * 4, in_dims * n_feats, kernel_size=1)
-        # nn.init.zeros_(_.weight)
-        # self.output_projection = nn.Sequential(
-            # nn.Conv1d(n_chans, n_chans * 4, kernel_size=1),
-            # nn.GELU(),
-            # _,
-        # )
     
     def forward(self, spec, diffusion_step, cond):
         """

--- a/modules/backbones/LYNXNet.py
+++ b/modules/backbones/LYNXNet.py
@@ -137,15 +137,15 @@ class LYNXNet(nn.Module):
             ]
         )
         self.norm = nn.LayerNorm(n_chans)
-        # self.output_projection = nn.Conv1d(n_chans, in_dims * n_feats, kernel_size=1)
-        # nn.init.zeros_(self.output_projection.weight)
-        _ = nn.Conv1d(n_chans * 4, in_dims * n_feats, kernel_size=1)
-        nn.init.zeros_(_.weight)
-        self.output_projection = nn.Sequential(
-            nn.Conv1d(n_chans, n_chans * 4, kernel_size=1),
-            nn.GELU(),
-            _,
-        )
+        self.output_projection = nn.Conv1d(n_chans, in_dims * n_feats, kernel_size=1)
+        nn.init.zeros_(self.output_projection.weight)
+        # _ = nn.Conv1d(n_chans * 4, in_dims * n_feats, kernel_size=1)
+        # nn.init.zeros_(_.weight)
+        # self.output_projection = nn.Sequential(
+            # nn.Conv1d(n_chans, n_chans * 4, kernel_size=1),
+            # nn.GELU(),
+            # _,
+        # )
     
     def forward(self, spec, diffusion_step, cond):
         """

--- a/modules/backbones/LYNXNet.py
+++ b/modules/backbones/LYNXNet.py
@@ -173,7 +173,7 @@ class LYNXNet(nn.Module):
             x = layer(x, cond, diffusion_step)
 
         # post-norm
-        x = self.norm(x)
+        x = self.norm(x.transpose(1, 2)).transpose(1, 2)
         
         # MLP and GLU
         x = self.output_projection(x)  # [B, 128, T]

--- a/modules/backbones/LYNXNet.py
+++ b/modules/backbones/LYNXNet.py
@@ -136,13 +136,13 @@ class LYNXNet(nn.Module):
                 for i in range(n_layers)
             ]
         )
-        self.norm = nn.LayerNorm(dim)
+        self.norm = nn.LayerNorm(n_chans)
         # self.output_projection = nn.Conv1d(n_chans, in_dims * n_feats, kernel_size=1)
         # nn.init.zeros_(self.output_projection.weight)
-        _ = nn.Conv1d(dim * mlp_factor, mel_channels, kernel_size=1)
+        _ = nn.Conv1d(n_chans * 4, in_dims * n_feats, kernel_size=1)
         nn.init.zeros_(_.weight)
         self.output_projection = nn.Sequential(
-            nn.Conv1d(dim, dim * mlp_factor, kernel_size=1),
+            nn.Conv1d(n_chans, n_chans * 4, kernel_size=1),
             nn.GELU(),
             _,
         )

--- a/modules/backbones/LYNXNet.py
+++ b/modules/backbones/LYNXNet.py
@@ -57,7 +57,6 @@ class LYNXConvModule(nn.Module):
     def __init__(self, dim, expansion_factor, kernel_size=31, in_norm=False, activation='PReLU', dropout=0.):
         super().__init__()
         inner_dim = dim * expansion_factor
-        _normalize = nn.LayerNorm(dim) if in_norm or dim > 512 else nn.Identity()
         activation_classes = {
             'SiLU': nn.SiLU,
             'ReLU': nn.ReLU,
@@ -73,7 +72,7 @@ class LYNXConvModule(nn.Module):
         else:
             _dropout = nn.Identity()
         self.net = nn.Sequential(
-            _normalize,
+            nn.LayerNorm(dim),
             Transpose((1, 2)),
             nn.Conv1d(dim, inner_dim * 2, 1),
             SwiGLU(dim=1),
@@ -137,9 +136,17 @@ class LYNXNet(nn.Module):
                 for i in range(n_layers)
             ]
         )
-        self.output_projection = nn.Conv1d(n_chans, in_dims * n_feats, kernel_size=1)
-        nn.init.zeros_(self.output_projection.weight)
-        
+        self.norm = nn.LayerNorm(dim)
+        # self.output_projection = nn.Conv1d(n_chans, in_dims * n_feats, kernel_size=1)
+        # nn.init.zeros_(self.output_projection.weight)
+        _ = nn.Conv1d(dim * mlp_factor, mel_channels, kernel_size=1)
+        nn.init.zeros_(_.weight)
+        self.output_projection = nn.Sequential(
+            nn.Conv1d(dim, dim * mlp_factor, kernel_size=1),
+            nn.GELU(),
+            _,
+        )
+    
     def forward(self, spec, diffusion_step, cond):
         """
         :param spec: [B, F, M, T]
@@ -164,6 +171,9 @@ class LYNXNet(nn.Module):
         
         for layer in self.residual_layers:
             x = layer(x, cond, diffusion_step)
+
+        # post-norm
+        x = self.norm(x)
         
         # MLP and GLU
         x = self.output_projection(x)  # [B, 128, T]


### PR DESCRIPTION
Add out norm to solve the issue of large numerical values when generating audio beyond the model's capabilities.
like this:
![图片](https://github.com/user-attachments/assets/45cb9d2f-0e49-486c-821c-fdd9d08a0bbd)
