### PR TITLE
Add Pytorch version check when export onnx

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -14,6 +14,16 @@ sys.path.insert(0, str(root_dir))
 from utils.hparams import set_hparams, hparams
 
 
+def check_pytorch_version():
+    version = torch.__version__
+    print(f"PyTorch version: {version}")
+    major, minor, _ = version.split('.')
+    if major != '1' and minor != '13':
+        raise RuntimeError(f"Unsupported PyTorch Version: {version}. need 1.13.x.")
+    else:
+        pass
+
+
 def find_exp(exp):
     if not (root_dir / 'checkpoints' / exp).exists():
         for subdir in (root_dir / 'checkpoints').iterdir():
@@ -291,4 +301,5 @@ def nsf_hifigan(
 
 
 if __name__ == '__main__':
+    check_pytorch_version()
     main()


### PR DESCRIPTION
在以前，使用Wavenet作为backbone时，onnx并不能在如pytorch2.0导出，故没有该功能的必要
现在，使用Lynxnet作为backbone时，不存在不能在高版本pytorch导出的情况
此外，很多时候在高版本pytorch导出的onnx也可以偶尔正常使用，少量测试难以发觉，但终究存在问题