### PR TITLE
stop checking for wrong Torch version

### DIFF
--- a/scripts/export.py
+++ b/scripts/export.py
@@ -298,5 +298,5 @@ def nsf_hifigan(
 
 
 if __name__ == '__main__':
-    check_pytorch_version()
+    #check_pytorch_version()
     main()


### PR DESCRIPTION
mix-LN export fails on 1.13, stop enforcing 1.13