### PR TITLE
Support variance ONNX export on PyTorch 2.x

### DIFF
--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -388,33 +388,47 @@ class DiffSingerVarianceExporter(BaseExporter):
             noise = torch.randn(shape, device=self.device)
             condition = torch.rand((1, hparams['hidden_size'], 15), device=self.device)
 
-            print(f'Tracing {self.pitch_backbone_class_name} backbone...')
             pitch_predictor = self.model.view_as_pitch_predictor()
-            pitch_predictor.pitch_predictor.set_backbone(
-                torch.jit.trace(
-                    pitch_predictor.pitch_predictor.backbone,
-                    (
-                        noise,
-                        dummy_time,
-                        condition
+
+            if torch.__version__.startswith('1.13.'):
+                print(f'Tracing {self.pitch_backbone_class_name} backbone...')
+                pitch_predictor.pitch_predictor.set_backbone(
+                    torch.jit.trace(
+                        pitch_predictor.pitch_predictor.backbone,
+                        (
+                            noise,
+                            dummy_time,
+                            condition
+                        )
                     )
                 )
-            )
 
-            print(f'Scripting {self.pitch_predictor_class_name}...')
-            pitch_predictor = torch.jit.script(
-                pitch_predictor,
-                example_inputs=[
-                    (
-                        condition.transpose(1, 2),
-                        1  # p_sample branch
-                    ),
-                    (
-                        condition.transpose(1, 2),
-                        dummy_steps  # p_sample_plms branch
-                    )
-                ]
-            )
+                print(f'Scripting {self.pitch_predictor_class_name}...')
+                pitch_predictor = torch.jit.script(
+                    pitch_predictor,
+                    example_inputs=[
+                        (
+                            condition.transpose(1, 2),
+                            1  # p_sample branch
+                        ),
+                        (
+                            condition.transpose(1, 2),
+                            dummy_steps  # p_sample_plms branch
+                        )
+                    ]
+                )
+            else:
+                print(f'Wrapping {self.pitch_predictor_class_name} for trace-based export...')
+
+                class _PitchPredWrapper(torch.nn.Module):
+                    def __init__(self, model):
+                        super().__init__()
+                        self.pitch_predictor = model.pitch_predictor
+
+                    def forward(self, pitch_cond, steps):
+                        return self.pitch_predictor(pitch_cond, steps=steps)
+
+                pitch_predictor = _PitchPredWrapper(pitch_predictor)
 
             print(f'Exporting {self.pitch_predictor_class_name}...')
             torch.onnx.export(
@@ -535,33 +549,47 @@ class DiffSingerVarianceExporter(BaseExporter):
             condition = torch.rand((1, hparams['hidden_size'], 15), device=self.device)
             step = (torch.rand((1,), device=self.device) * hparams['K_step']).long()
 
-            print(f'Tracing {self.variance_backbone_class_name} backbone...')
             multi_var_predictor = self.model.view_as_variance_predictor()
-            multi_var_predictor.variance_predictor.set_backbone(
-                torch.jit.trace(
-                    multi_var_predictor.variance_predictor.backbone,
-                    (
-                        noise,
-                        step,
-                        condition
+
+            if torch.__version__.startswith('1.13.'):
+                print(f'Tracing {self.variance_backbone_class_name} backbone...')
+                multi_var_predictor.variance_predictor.set_backbone(
+                    torch.jit.trace(
+                        multi_var_predictor.variance_predictor.backbone,
+                        (
+                            noise,
+                            step,
+                            condition
+                        )
                     )
                 )
-            )
 
-            print(f'Scripting {self.multi_var_predictor_class_name}...')
-            multi_var_predictor = torch.jit.script(
-                multi_var_predictor,
-                example_inputs=[
-                    (
-                        condition.transpose(1, 2),
-                        1  # p_sample branch
-                    ),
-                    (
-                        condition.transpose(1, 2),
-                        dummy_steps  # p_sample_plms branch
-                    )
-                ]
-            )
+                print(f'Scripting {self.multi_var_predictor_class_name}...')
+                multi_var_predictor = torch.jit.script(
+                    multi_var_predictor,
+                    example_inputs=[
+                        (
+                            condition.transpose(1, 2),
+                            1  # p_sample branch
+                        ),
+                        (
+                            condition.transpose(1, 2),
+                            dummy_steps  # p_sample_plms branch
+                        )
+                    ]
+                )
+            else:
+                print(f'Wrapping {self.multi_var_predictor_class_name} for trace-based export...')
+
+                class _VarPredWrapper(torch.nn.Module):
+                    def __init__(self, model):
+                        super().__init__()
+                        self.variance_predictor = model.variance_predictor
+
+                    def forward(self, variance_cond, steps):
+                        return self.variance_predictor(variance_cond, steps=steps)
+
+                multi_var_predictor = _VarPredWrapper(multi_var_predictor)
 
             print(f'Exporting {self.multi_var_predictor_class_name}...')
             torch.onnx.export(

--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -188,6 +188,8 @@ class DiffSingerVarianceExporter(BaseExporter):
 
     @torch.no_grad()
     def _torch_export_model(self):
+        is_torch_113 = torch.__version__.startswith('1.13.')
+
         # Prepare inputs for FastSpeech2 and dur predictor tracing
         tokens = torch.LongTensor([[1] * 5]).to(self.device)
         ph_dur = torch.LongTensor([[3, 5, 2, 1, 4]]).to(self.device)
@@ -390,7 +392,7 @@ class DiffSingerVarianceExporter(BaseExporter):
 
             pitch_predictor = self.model.view_as_pitch_predictor()
 
-            if torch.__version__.startswith('1.13.'):
+            if is_torch_113:
                 print(f'Tracing {self.pitch_backbone_class_name} backbone...')
                 pitch_predictor.pitch_predictor.set_backbone(
                     torch.jit.trace(
@@ -551,7 +553,7 @@ class DiffSingerVarianceExporter(BaseExporter):
 
             multi_var_predictor = self.model.view_as_variance_predictor()
 
-            if torch.__version__.startswith('1.13.'):
+            if is_torch_113:
                 print(f'Tracing {self.variance_backbone_class_name} backbone...')
                 multi_var_predictor.variance_predictor.set_backbone(
                     torch.jit.trace(

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -20,7 +20,7 @@ def check_pytorch_version():
         return
     warnings.warn(
         f'ONNX export is tested on PyTorch 1.13.x, but you have {torch.__version__}. '
-        f'Proceeding with trace-based fallback for variance models.'
+        f'Export may not behave as expected with this PyTorch version.'
     )
 
 

--- a/scripts/export.py
+++ b/scripts/export.py
@@ -15,10 +15,13 @@ from utils.hparams import set_hparams, hparams
 
 
 def check_pytorch_version():
-    # Require PyTorch version to be exactly 1.13.x
+    import warnings
     if torch.__version__.startswith('1.13.'):
         return
-    raise RuntimeError('This script requires PyTorch 1.13.x. Please install the correct version.')
+    warnings.warn(
+        f'ONNX export is tested on PyTorch 1.13.x, but you have {torch.__version__}. '
+        f'Proceeding with trace-based fallback for variance models.'
+    )
 
 
 def find_exp(exp):


### PR DESCRIPTION
## Summary

The variance model ONNX export currently requires PyTorch 1.13.x because `torch.jit.script` is used on models returned by `view_as_*_predictor()`. On PyTorch 2.x, this fails with `RuntimeError: Unsupported value kind: Tensor` because TorchScript attempts to compile all methods on the class, including those that reference attributes removed by `deepcopy` + `del` in the `view_as_*` methods.

This PR:
- Adds a trace-based fallback for PyTorch 2.x using lightweight wrapper modules passed directly to `torch.onnx.export`
- Preserves the original `torch.jit.script` path for PyTorch 1.13.x
- Relaxes the hard version check in `export.py` to a warning

## Tested on
- PyTorch 1.13.1+cpu (Python 3.10) - original script path works
- PyTorch 2.7.0+cu128 (Python 3.11) - trace-based fallback works
- Exported ONNX models load and run correctly in OpenUTAU