### PR TITLE
perf(optim): implement Gram Newton-Schulz for Muon

### DIFF
--- a/modules/optimizer/muon.py
+++ b/modules/optimizer/muon.py
@@ -10,25 +10,7 @@ from .chained_optimizer import ChainedOptimizer, OptimizerSpec
 from modules.commons.common_layers import AdamWLinear, AdamWConv1d
 
 
-def get_bf16_support_map():
-    bf16_support_map = {}
-
-    if not torch.cuda.is_available():
-        return bf16_support_map
-
-    device_count = torch.cuda.device_count()
-    if device_count == 0:
-        return bf16_support_map
-
-    for i in range(device_count):
-        device = torch.device(f'cuda:{i}')       
-        major, minor = torch.cuda.get_device_capability(device)
-        bf16_support_map[device] = (major >= 8)
-        
-    return bf16_support_map
-    
-    
-def zeropower_via_newtonschulz5(G: Tensor, steps: int, use_bf16: bool) -> Tensor:
+def zeropower_via_newtonschulz5(G: Tensor, steps: int) -> Tensor:
     """
     Newton-Schulz iteration to compute the zeroth power / orthogonalization of G. We opt to use a
     quintic iteration whose coefficients are selected to maximize the slope at zero. For the purpose
@@ -41,10 +23,12 @@ def zeropower_via_newtonschulz5(G: Tensor, steps: int, use_bf16: bool) -> Tensor
     assert G.ndim == 3 # batched Muon implementation by @scottjmaddox, and put into practice in the record by @YouJiacheng
     a, b, c = (3.4445, -4.7750,  2.0315)
     
-    X = G.to(dtype = torch.bfloat16 if use_bf16 else torch.float32)
+    X = G.to(torch.float32)
 
     # Ensure spectral norm is at most 1
     X = F.normalize(X, p=2.0, dim=(-2, -1), eps=1e-7)
+    
+    X = X.to(torch.float16)
     
     # Perform the NS iterations
     if X.size(-2) < X.size(-1):
@@ -59,6 +43,57 @@ def zeropower_via_newtonschulz5(G: Tensor, steps: int, use_bf16: bool) -> Tensor
             X = torch.baddbmm(X, X, A, beta=a, alpha=1)
             
     return X
+
+
+def gram_newton_schulz(G: Tensor, steps: int, reset_iterations: List[int]=[2]) -> Tensor:
+    """
+    Refer to: 
+    Gram Newton-Schulz: A Fast, Hardware-Aware Newton-Schulz Algorithm for Muon
+    Authors: Jack Zhang, Noah Amsel, Berlin Chen, Tri Dao
+    Blogpost: https://dao-ailab.github.io/blog/2026/gram-newton-schulz/
+    
+    Gram Newton-Schulz iteration to compute the orthogonalization of G.
+    Mathematically identical to standard Newton-Schulz but computes iterating 
+    on the smaller NxN Gram matrix to save up to 50% FLOPs.
+    """
+    assert G.ndim == 3
+    original_shape = G.shape
+    dtype = G.dtype
+
+    X = G.to(torch.float32)
+    X = F.normalize(X, p=2.0, dim=(-2, -1), eps=1e-7)
+    should_transpose = X.size(-2) > X.size(-1)
+    if should_transpose:
+        X = X.mT
+    X = X.to(torch.float16)
+
+    a, b, c = (3.4445, -4.7750,  2.0315)
+
+    if X.size(-2) != X.size(-1):
+        R = torch.bmm(X, X.mT)
+        Q = None
+        for i in range(steps):
+            if i in reset_iterations and i != 0:
+                X = torch.bmm(Q, X)
+                R = torch.bmm(X, X.mT)
+                Q = None
+            Z = torch.baddbmm(R, R, R, beta=b, alpha=c)
+            if i != 0 and i not in reset_iterations:
+                Q = torch.baddbmm(Q, Q, Z, beta=a, alpha=1.0)
+            else:
+                Q = Z.clone()
+                Q.diagonal(dim1=-2, dim2=-1).add_(a)
+            if i < steps - 1 and (i + 1) not in reset_iterations:
+                RZ = torch.baddbmm(R, R, Z, beta=a, alpha=1.0)
+                R = torch.baddbmm(RZ, Z, RZ, beta=a, alpha=1.0)
+        X = torch.bmm(Q, X) if not should_transpose else torch.bmm(X.mT, Q)
+    else:
+        for _ in range(steps):
+            A = torch.bmm(X, X.mT)
+            B = torch.baddbmm(A, A, A, beta=b, alpha=c)
+            X = torch.baddbmm(X, B, X, beta=a, alpha=1.0)
+
+    return X.to(dtype).view(original_shape)
 
 
 class Muon(torch.optim.Optimizer):
@@ -87,7 +122,6 @@ class Muon(torch.optim.Optimizer):
     def __init__(self, params, lr=5e-4, weight_decay=0.1, momentum=0.95, nesterov=True, ns_steps=5):
         defaults = dict(lr=lr, weight_decay=weight_decay, momentum=momentum, nesterov=nesterov, ns_steps=ns_steps)
         super().__init__(params, defaults)
-        self.bf16_support_map = get_bf16_support_map()
     
     @torch.no_grad()
     def step(self, closure=None):
@@ -116,8 +150,8 @@ class Muon(torch.optim.Optimizer):
                 original_shape = g.shape
                 if g.ndim >= 4:  # for the case of conv filters
                     g = g.view(g.size(0), g.size(1), -1)
-                use_bf16 = self.bf16_support_map.get(g.device, False)
-                g = zeropower_via_newtonschulz5(g, steps=group["ns_steps"], use_bf16=use_bf16)
+                g = gram_newton_schulz(g, steps=group["ns_steps"])
+                
                 if group["weight_decay"] > 0:
                     torch._foreach_mul_(p, 1 - group["lr"] * group["weight_decay"])
                 torch._foreach_add_(p, g.view(original_shape).unbind(0), alpha=-group["lr"] * max(g[0].size()) ** 0.5)


### PR DESCRIPTION
## Description
This PR optimizes the orthogonalization step in the Muon optimizer by integrating the Gram Newton-Schulz (GramNS) algorithm. Additionally, it addresses a known training stability issue when using `float16`.

## Key Changes
* **Stability Fix:** We discovered that performing the initial spectral normalization in `float32` is sufficient to prevent gradient overflow/underflow. This allows the subsequent Newton-Schulz iterations to run stably in `float16` without strictly requiring `bfloat16`.
* **GramNS Integration:** Replaced the standard Newton-Schulz 5 (NS5) iteration with GramNS, computing iterations on the smaller NxN Gram matrix to significantly save FLOPs on rectangular matrices.

## Benchmarks
Performance comparison between standard NS5 and GramNS (Batch Size = 8). 
GramNS demonstrates massive efficiency gains on highly rectangular matrices (up to ~40% time reduction for `8192x1024`), while maintaining parity on square matrices.

| Shape | Batch | NS5 (ms) | GramNS (ms) | Ratio (GramNS / NS5) |
| :--- | :--- | :--- | :--- | :--- |
| (512, 512) | 8 | 2.8512 | 2.7637 | 0.969 |
| (1024, 1024) | 8 | 10.2181 | 10.6101 | 1.038 |
| (2048, 2048) | 8 | 75.5655 | 74.7877 | 0.990 |
| (4096, 4096) | 8 | 571.8510 | 582.7745 | 1.019 |
| (2048, 1024) | 8 | 17.1982 | 16.5473 | 0.962 |
| (1024, 2048) | 8 | 19.1216 | 16.0166 | 0.838 |
| (4096, 1024) | 8 | 30.4058 | 21.5448 | 0.709 |
| (1024, 4096) | 8 | 31.9332 | 22.8621 | 0.716 |
| (8192, 1024) | 8 | 57.0449 | 34.1205 | 0.598 |
| (1024, 8192) | 8 | 58.2899 | 33.4286 | 0.573 |
| (4096, 2048) | 8 | 122.8127 | 111.8067 | 0.910 |
| (2048, 4096) | 8 | 123.4342 | 110.8306 | 0.898 |
| (8192, 4096) | 8 | 969.0377 | 893.7069 | 0.922 |
| (4096, 8192) | 8 | 1017.5225 | 917.9643 | 0.902 |