### PR TITLE
Update ignored patterns in variance exporter

### DIFF
--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 from typing import Union, List, Tuple, Dict
 
@@ -761,8 +762,12 @@ class DiffSingerVarianceExporter(BaseExporter):
 
         var_post = onnx_helper.simplify_onnx(var_post)
 
-        ignored_variance_names = '|'.join([f'({v_name})' for v_name in self.model.variance_prediction_list])
-        ignored_variance_pred_names = '|'.join([f'({v_name}_pred)' for v_name in self.model.variance_prediction_list])
+        ignored_variance_names = '|'.join(
+            f'({re.escape(v_name)})' for v_name in self.model.variance_prediction_list
+        ) if self.model.variance_prediction_list else '(?!)'
+        ignored_variance_pred_names = '|'.join(
+            f'({re.escape(v_name)}_pred)' for v_name in self.model.variance_prediction_list
+        ) if self.model.variance_prediction_list else '(?!)'
         onnx_helper.model_add_prefixes(
             var_pre, node_prefix='/pre', value_info_prefix='/pre', initializer_prefix='/pre',
             ignored_pattern=fr'.*((embed)|(variance_cond)|{ignored_variance_names}).*'

--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -706,7 +706,10 @@ class DiffSingerVarianceExporter(BaseExporter):
 
         onnx_helper.model_add_prefixes(pitch_pre, node_prefix='/pre', ignored_pattern=r'.*embed.*')
         onnx_helper.model_add_prefixes(pitch_pre, dim_prefix='pre.', ignored_pattern='(n_tokens)|(n_notes)|(n_frames)')
-        onnx_helper.model_add_prefixes(pitch_post, node_prefix='/post', ignored_pattern=None)
+        onnx_helper.model_add_prefixes(
+            pitch_post, node_prefix='/post', value_info_prefix='/post', initializer_prefix='/post',
+            ignored_pattern=r'.*(pitch_pred).*'
+        )
         onnx_helper.model_add_prefixes(pitch_post, dim_prefix='post.', ignored_pattern='n_frames')
         pitch_pre_diffusion = onnx.compose.merge_models(
             pitch_pre, pitch_predictor, io_map=[('pitch_cond', 'pitch_cond')],

--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -759,14 +759,15 @@ class DiffSingerVarianceExporter(BaseExporter):
         var_post = onnx_helper.simplify_onnx(var_post)
 
         ignored_variance_names = '|'.join([f'({v_name})' for v_name in self.model.variance_prediction_list])
+        ignored_variance_pred_names = '|'.join([f'({v_name}_pred)' for v_name in self.model.variance_prediction_list])
         onnx_helper.model_add_prefixes(
             var_pre, node_prefix='/pre', value_info_prefix='/pre', initializer_prefix='/pre',
-            ignored_pattern=fr'.*((embed)|{ignored_variance_names}).*'
+            ignored_pattern=fr'.*((embed)|(variance_cond)|{ignored_variance_names}).*'
         )
         onnx_helper.model_add_prefixes(var_pre, dim_prefix='pre.', ignored_pattern='(n_tokens)|(n_frames)')
         onnx_helper.model_add_prefixes(
             var_post, node_prefix='/post', value_info_prefix='/post', initializer_prefix='/post',
-            ignored_pattern=None
+            ignored_pattern=fr'.*({ignored_variance_pred_names}).*'
         )
         onnx_helper.model_add_prefixes(var_post, dim_prefix='post.', ignored_pattern='n_frames')
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -6,7 +6,7 @@
 
 DiffSinger requires Python 3.10 or later. We strongly recommend you create a virtual environment via Conda, venv or uv before installing dependencies.
 
-1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using the latest stable release that is ≥ 2.4.0.
+1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using version ≥ 2.4.0, ≤ 2.8.0.
 
 2. Install other dependencies via the following command:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -6,7 +6,7 @@
 
 DiffSinger requires Python 3.10 or later. We strongly recommend you create a virtual environment via Conda, venv or uv before installing dependencies.
 
-1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using version ≥ 2.4.0, ≤ 2.8.0.
+1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using version ≥ 2.4.0, preferably ≤ 2.8.0.
 
 2. Install other dependencies via the following command:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -6,7 +6,7 @@
 
 DiffSinger requires Python 3.10 or later. We strongly recommend you create a virtual environment via Conda, venv or uv before installing dependencies.
 
-1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using version ≥ 2.4.0, preferably ≤ 2.8.0.
+1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using version >= 2.4.0, preferably <= 2.8.0.
 
 2. Install other dependencies via the following command:
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -4,7 +4,7 @@
 
 ### Environments and dependencies
 
-DiffSinger requires Python 3.8 or later. We strongly recommend you create a virtual environment via Conda, venv or uv before installing dependencies.
+DiffSinger requires Python 3.10 or later. We strongly recommend you create a virtual environment via Conda, venv or uv before installing dependencies.
 
 1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using the latest stable release that is ≥ 2.4.0.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # It is recommended to install PyTorch manually.
-# PyTorch >= 2.4 is recommended.
+# PyTorch >= 2.4, <= 2.8 is recommended.
 # See instructions at https://pytorch.org/get-started/locally/
 
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # It is recommended to install PyTorch manually.
-# PyTorch >= 2.4, <= 2.8 is recommended.
+# PyTorch >= 2.4, preferably <= 2.8 is recommended.
 # See instructions at https://pytorch.org/get-started/locally/
 
 click


### PR DESCRIPTION
  This PR fixes three ONNX export failures that occur when using `onnxslim` with `onnx>=1.20.0`. The root cause in all
  three cases is the same pattern:

  **`model_add_prefixes` renames value_info entries, but graph output/input tensors that happen to also appear in
  `value_info` get incorrectly renamed while the graph interface names stay unchanged.** This creates an inconsistency
  that `onnx>=1.20`'s stricter `checker.check_model()` catches (topological sort or overlapping-name validation).

  ### Fix 1: `variance_cond` output of variance preprocessor

  `var_pre`'s graph output `variance_cond` lives in `value_info` after onnxslim simplification. When
  `model_add_prefixes` adds the `/pre` prefix, it renames `variance_cond` → `/prevariance_cond` in both `value_info` and
  the producing node's output, but the graph output remains `variance_cond`. The subsequent `merge_models` call with
  `io_map=[('variance_cond', 'variance_cond')]` fails because no node produces `variance_cond` anymore.

  **Fix:** Add `(variance_cond)` to the `ignored_pattern` in the `var_pre` prefix call.

  ### Fix 2: `{variance}_pred` outputs of variance postprocessor

  Same pattern as Fix 1. The variance postprocessor's outputs (e.g. `breathiness_pred`, `voicing_pred`, `tension_pred`)
  are in `value_info` and get prefixed with `/post`, breaking the graph.

  **Fix:** Generate `ignored_variance_pred_names` from `self.model.variance_prediction_list` and use it as the
  `ignored_pattern` in the `var_post` prefix call.

  ### Fix 3: Overlapping edge names in pitch merge

  `pitch_post` only had `node_prefix='/post'`, leaving its `value_info` and `initializer` names unprefixed. With
  `onnxslim` simplification, these can overlap with names from `pitch_pre_diffusion`, causing `merge_models`
  (onnx>=1.20) to reject: `"Found repeated edge names: /Constant_1_output_0"`.

  **Fix:** Add `value_prefix='/post'` and `initializer_prefix='/post'` to `pitch_post`'s prefix call (matching the
  pattern already used by `var_post`). Exclude `pitch_pred` from prefixing since it's the graph output.

  ### Verification

  Tested on:
  - `torch 2.8.0 + onnxslim 0.1.94 + onnx 1.22.0` — all three ONNX models (linguistic, pitch, variance) export
  successfully
  - `onnxsim` also works as the simplification backend; the fixes make the export robust regardless of which simplifier
  is used