### PR TITLE
fix(deploy): 用 concat 替代导出路径里的前置 F.pad（修复 LengthRegulator mel2ph 塌缩）

### DIFF
--- a/deployment/modules/fastspeech2.py
+++ b/deployment/modules/fastspeech2.py
@@ -47,7 +47,9 @@ class LengthRegulator(nn.Module):
     def forward(self, dur):
         token_idx = torch.arange(1, dur.shape[1] + 1, device=dur.device)[None, :, None]
         dur_cumsum = torch.cumsum(dur, dim=1)
-        dur_cumsum_prev = F.pad(dur_cumsum, (1, -1), mode='constant', value=0)
+        # NOTE: a leading F.pad here can be exported to ONNX with its begin/end pad amounts
+        # reversed; use an explicit concat (export-stable, cf. uniform_attention_pooling).
+        dur_cumsum_prev = torch.cat([torch.zeros_like(dur_cumsum[:, :1]), dur_cumsum[:, :-1]], dim=1)
         pos_idx = torch.arange(dur.sum(dim=1).max(), device=dur.device)[None, None]
         token_mask = (pos_idx >= dur_cumsum_prev[:, :, None]) & (pos_idx < dur_cumsum[:, :, None])
         mel2ph = (token_idx * token_mask).sum(dim=1)
@@ -111,7 +113,8 @@ class FastSpeech2AcousticONNX(FastSpeech2Acoustic):
         else:
             ph_spk_embed = None
         encoded = self.encoder(txt_embed, extra_embed, tokens == PAD_INDEX, spk_embed=ph_spk_embed)
-        encoded = F.pad(encoded, (0, 0, 1, 0))
+        # NOTE: front-pad via concat (a leading F.pad can be exported with begin/end reversed).
+        encoded = torch.cat([torch.zeros_like(encoded[:, :1]), encoded], dim=1)
         condition = torch.gather(encoded, 1, mel2ph)
 
         if self.use_stretch_embed:
@@ -178,9 +181,10 @@ class FastSpeech2VarianceONNX(FastSpeech2Variance):
     def forward_encoder_word(self, tokens, word_div, word_dur, languages=None):
         txt_embed = self.txt_embed(tokens)
         ph2word = self.lr(word_div)
-        onset = ph2word > F.pad(ph2word, [1, -1])
+        # NOTE: front-pad via concat (a leading F.pad can be exported with begin/end reversed).
+        onset = ph2word > torch.cat([torch.zeros_like(ph2word[:, :1]), ph2word[:, :-1]], dim=1)
         onset_embed = self.onset_embed(onset.long())
-        ph_word_dur = torch.gather(F.pad(word_dur, [1, 0]), 1, ph2word)
+        ph_word_dur = torch.gather(torch.cat([torch.zeros_like(word_dur[:, :1]), word_dur], dim=1), 1, ph2word)
         word_dur_embed = self.word_dur_embed(ph_word_dur.float()[:, :, None])
         extra_embed = onset_embed + word_dur_embed
         if self.use_lang_id:

--- a/deployment/modules/toplevel.py
+++ b/deployment/modules/toplevel.py
@@ -214,11 +214,12 @@ class DiffSingerVarianceONNX(DiffSingerVariance):
     def forward_mel2x_gather(self, x_src, x_dur, x_dim=None, check_stretch_embed=False):
         mel2x = self.lr(x_dur)
         _mel2x = mel2x
+        # NOTE: front-pad via concat (a leading F.pad can be exported with begin/end reversed).
         if x_dim is not None:
-            x_src = F.pad(x_src, [0, 0, 1, 0])
+            x_src = torch.cat([torch.zeros_like(x_src[:, :1]), x_src], dim=1)
             mel2x = mel2x[..., None].repeat([1, 1, x_dim])
         else:
-            x_src = F.pad(x_src, [1, 0])
+            x_src = torch.cat([torch.zeros_like(x_src[:, :1]), x_src], dim=1)
         x_cond = torch.gather(x_src, 1, mel2x)
         if self.use_stretch_embed and check_stretch_embed:
             stretch = torch.round(1000 * self.sr(_mel2x, x_dur))


### PR DESCRIPTION
## 现象

在 PyTorch 2.x 环境下导出 variance/acoustic 模型时，部署版 `LengthRegulator` / encoder 里的 `F.pad` **前置填充**被导出成了 begin/end 填充量**对调**的 `Pad`：

| 源码 | 期望 ONNX pads | 实际导出 |
|---|---|---|
| `LengthRegulator`: `F.pad(dur_cumsum, (1, -1))` | `[0,1,0,-1]` | `[0,-1,0,1]` ❌ |
| encoder 前填充: `F.pad(encoded/x_src, (...,1,0))` | `[0,1,0,0,0,0]` | `[0,0,0,0,1,0]` ❌ |

后果：每个 token 的起始边界被移到错误一侧 → `mel2ph` 塌缩，**每一帧都被映射到最后一个音素** → `condition` 全错，再被扩散采样器放大。已导出的老模型不受影响（正确的 pad 已烘进图里）；只有用新环境**重新导出**才会中招。

## 证据

对比同一 ckpt 的两份导出：

- 正常：producer `pytorch 1.13.1` / opset 15 → pad 正确、mel2ph `[1,1,..,2,2,..,N,N]`。
- 损坏：producer `pytorch 2.x` / opset 17 → pad 翻转、mel2ph `[N,N,…,N]`。

**决定性验证**：在损坏图里**只**把这两个 pad 常量改回去（`[0,-1,0,1]→[0,1,0,-1]`、`[0,0,0,0,1,0]→[0,1,0,0,0,0]`），输出与正常图**逐比特一致**（`variance_cond` max-abs-diff = 0，终值 ~1e-6）。所以 pad 翻转就是这个回归的**全部**病因——手写 attention、wavenet `[:,0]`、opset 15→17、烘焙 diffusion-embedding 常量全部数值等价。

已排除：onnxslim **不会**破坏本来正确的 pad 常量；opset 15→17 的 `Pad` 语义不变。

## 想请维护者确认的两点

1. 你们用当前/pin 的导出环境导 variance 模型，能复现 mel2ph 塌缩吗？（我无法确认这是不是某个特定 torch 构建独有。）
2. 触发源是 PyTorch 版本（torch 2.x 导出器对 `F.pad` 的处理），还是统一环境时移除/改动了某个导出前的简化/归一化步骤？

## 本 PR 的改法

把导出路径里这些前置 `F.pad(...)` 改写成显式的 `torch.cat([torch.zeros_like(x[:, :1]), x], dim=1)`（带 `-1` 裁剪的再切一刀）——也就是 `uniform_attention_pooling` 里**已经在用**的导出稳定写法。它彻底绕开 `Pad` 算子，无论根因是上面哪一个都成立。改动仅限 `deployment/modules/fastspeech2.py` 与 `deployment/modules/toplevel.py`。

> 说明：本 PR 的"修复正确性"已由图手术证明（patch 两个 pad 常量即 bit 级恢复）；但"`torch.cat` 改写在 torch 2.x 下确实导出成正确 pad"的端到端正向验证尚未做（提交者本地无 torch 环境）。如方便，欢迎在你们环境实导一次确认。
