### PR TITLE
fix: Roll back the changes related to onnxslim in #308 and #305

### DIFF
--- a/deployment/exporters/acoustic_exporter.py
+++ b/deployment/exporters/acoustic_exporter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Union, List, Tuple, Dict
 
 import onnx
+import onnxsim
 import torch
 import yaml
 
@@ -346,7 +347,8 @@ class DiffSingerAcousticExporter(BaseExporter):
 
     def _optimize_fs2_aux_graph(self, fs2: onnx.ModelProto) -> onnx.ModelProto:
         print(f'Running ONNX Simplifier on {self.fs2_aux_class_name}...')
-        fs2 = onnx_helper.simplify_onnx(fs2)
+        fs2, check = onnxsim.simplify(fs2, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         onnx_helper.model_reorder_io_list(
             fs2, 'input',
             target_name='languages', insert_after_name='tokens'
@@ -358,13 +360,9 @@ class DiffSingerAcousticExporter(BaseExporter):
         onnx_helper.model_override_io_shapes(diffusion, output_shapes={
             'mel': (1, 'n_frames', hparams['audio_num_mel_bins'])
         })
-        # Running simplify_onnx here used to be "Simplifier #1", but the
-        # subsequent graph_extract_conditioner_projections call mutates
-        # the topology in ways that can collide with simplifier output
-        # ordering (causing the merged model to fail topological-sort
-        # validation downstream). The second simplifier pass below handles
-        # everything that the dropped first pass did, so removing it is
-        # both safe and a fix for a latent merge bug.
+        print(f'Running ONNX Simplifier #1 on {self.diffusion_class_name}...')
+        diffusion, check = onnxsim.simplify(diffusion, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         onnx_helper.graph_fold_back_to_squeeze(diffusion.graph)
         onnx_helper.graph_extract_conditioner_projections(
             graph=diffusion.graph, op_type='Conv',
@@ -372,8 +370,12 @@ class DiffSingerAcousticExporter(BaseExporter):
             alias_prefix='/diffusion/backbone/cache'
         )
         onnx_helper.graph_remove_unused_values(diffusion.graph)
-        print(f'Running ONNX Simplifier on {self.diffusion_class_name}...')
-        diffusion = onnx_helper.simplify_onnx(diffusion)
+        print(f'Running ONNX Simplifier #2 on {self.diffusion_class_name}...')
+        diffusion, check = onnxsim.simplify(
+            diffusion,
+            include_subgraph=True
+        )
+        assert check, 'Simplified ONNX model could not be validated'
         print(f'| optimize graph: {self.diffusion_class_name}')
         return diffusion
 
@@ -397,7 +399,11 @@ class DiffSingerAcousticExporter(BaseExporter):
         merged.graph.name = fs2.graph.name
 
         print(f'Running ONNX Simplifier on {self.model_class_name}...')
-        merged = onnx_helper.simplify_onnx(merged)
+        merged, check = onnxsim.simplify(
+            merged,
+            include_subgraph=True
+        )
+        assert check, 'Simplified ONNX model could not be validated'
         print(f'| optimize graph: {self.model_class_name}')
 
         return merged

--- a/deployment/exporters/nsf_hifigan_exporter.py
+++ b/deployment/exporters/nsf_hifigan_exporter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Union
 
 import onnx
+import onnxsim
 import torch
 import yaml
 from torch import nn
@@ -121,5 +122,6 @@ class NSFHiFiGANExporter(BaseExporter):
 
     def _optimize_model_graph(self, model: onnx.ModelProto) -> onnx.ModelProto:
         print(f'Running ONNX simplifier for {self.model_class_name}...')
-        model = onnx_helper.simplify_onnx(model)
+        model, check = onnxsim.simplify(model, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         return model

--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -746,8 +746,7 @@ class DiffSingerVarianceExporter(BaseExporter):
                 else (1, len(self.model.variance_prediction_list), 'n_frames')
             }
         )
-        print(f'Running ONNX Simplifier #1 on'
-              f' {self.multi_var_predictor_class_name}...')
+        print(f'Running ONNX Simplifier #1 on {self.multi_var_predictor_class_name}...')
         var_diffusion, check = onnxsim.simplify(var_diffusion, include_subgraph=True)
         assert check, 'Simplified ONNX model could not be validated'
         onnx_helper.graph_fold_back_to_squeeze(var_diffusion.graph)

--- a/deployment/exporters/variance_exporter.py
+++ b/deployment/exporters/variance_exporter.py
@@ -1,9 +1,9 @@
 import json
-import re
 from pathlib import Path
 from typing import Union, List, Tuple, Dict
 
 import onnx
+import onnxsim
 import torch
 import yaml
 
@@ -659,7 +659,8 @@ class DiffSingerVarianceExporter(BaseExporter):
             }
         )
         print(f'Running ONNX Simplifier on {self.fs2_class_name}...')
-        linguistic = onnx_helper.simplify_onnx(linguistic)
+        linguistic, check = onnxsim.simplify(linguistic, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         onnx_helper.model_reorder_io_list(
             linguistic, 'input',
             target_name='languages', insert_after_name='tokens'
@@ -675,7 +676,8 @@ class DiffSingerVarianceExporter(BaseExporter):
             }
         )
         print(f'Running ONNX Simplifier on {self.dur_predictor_class_name}...')
-        dur_predictor = onnx_helper.simplify_onnx(dur_predictor)
+        dur_predictor, check = onnxsim.simplify(dur_predictor, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         print(f'| optimize graph: {self.dur_predictor_class_name}')
         return dur_predictor
 
@@ -685,16 +687,15 @@ class DiffSingerVarianceExporter(BaseExporter):
         onnx_helper.model_override_io_shapes(
             pitch_pre, output_shapes={'pitch_cond': (1, 'n_frames', hparams['hidden_size'])}
         )
-        pitch_pre = onnx_helper.simplify_onnx(pitch_pre)
+        pitch_pre, check = onnxsim.simplify(pitch_pre, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
 
         onnx_helper.model_override_io_shapes(
             pitch_predictor, output_shapes={'pitch_pred': (1, 'n_frames')}
         )
-        # See acoustic_exporter._optimize_diffusion_graph: the pre-surgery
-        # simplifier pass was dropped because the conditioner-projection
-        # extraction below can produce a topology that collides with the
-        # simplifier's output, causing merge_models to fail topological-sort
-        # validation. The post-surgery simplifier handles the same work.
+        print(f'Running ONNX Simplifier #1 on {self.pitch_predictor_class_name}...')
+        pitch_predictor, check = onnxsim.simplify(pitch_predictor, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         onnx_helper.graph_fold_back_to_squeeze(pitch_predictor.graph)
         onnx_helper.graph_extract_conditioner_projections(
             graph=pitch_predictor.graph, op_type='Conv',
@@ -702,15 +703,13 @@ class DiffSingerVarianceExporter(BaseExporter):
             alias_prefix='/pitch_predictor/backbone/cache'
         )
         onnx_helper.graph_remove_unused_values(pitch_predictor.graph)
-        print(f'Running ONNX Simplifier on {self.pitch_predictor_class_name}...')
-        pitch_predictor = onnx_helper.simplify_onnx(pitch_predictor)
+        print(f'Running ONNX Simplifier #2 on {self.pitch_predictor_class_name}...')
+        pitch_predictor, check = onnxsim.simplify(pitch_predictor, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
 
         onnx_helper.model_add_prefixes(pitch_pre, node_prefix='/pre', ignored_pattern=r'.*embed.*')
         onnx_helper.model_add_prefixes(pitch_pre, dim_prefix='pre.', ignored_pattern='(n_tokens)|(n_notes)|(n_frames)')
-        onnx_helper.model_add_prefixes(
-            pitch_post, node_prefix='/post', value_info_prefix='/post', initializer_prefix='/post',
-            ignored_pattern=r'.*(pitch_pred).*'
-        )
+        onnx_helper.model_add_prefixes(pitch_post, node_prefix='/post', ignored_pattern=None)
         onnx_helper.model_add_prefixes(pitch_post, dim_prefix='post.', ignored_pattern='n_frames')
         pitch_pre_diffusion = onnx.compose.merge_models(
             pitch_pre, pitch_predictor, io_map=[('pitch_cond', 'pitch_cond')],
@@ -737,7 +736,8 @@ class DiffSingerVarianceExporter(BaseExporter):
         onnx_helper.model_override_io_shapes(
             var_pre, output_shapes={'variance_cond': (1, 'n_frames', hparams['hidden_size'])}
         )
-        var_pre = onnx_helper.simplify_onnx(var_pre)
+        var_pre, check = onnxsim.simplify(var_pre, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
 
         onnx_helper.model_override_io_shapes(
             var_diffusion, output_shapes={
@@ -746,10 +746,10 @@ class DiffSingerVarianceExporter(BaseExporter):
                 else (1, len(self.model.variance_prediction_list), 'n_frames')
             }
         )
-        # See acoustic_exporter._optimize_diffusion_graph: pre-surgery
-        # simplifier dropped to avoid a latent topology collision with the
-        # conditioner-projection extraction; the post-surgery pass covers
-        # the same simplifications.
+        print(f'Running ONNX Simplifier #1 on'
+              f' {self.multi_var_predictor_class_name}...')
+        var_diffusion, check = onnxsim.simplify(var_diffusion, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
         onnx_helper.graph_fold_back_to_squeeze(var_diffusion.graph)
         onnx_helper.graph_extract_conditioner_projections(
             graph=var_diffusion.graph, op_type='Conv',
@@ -757,25 +757,22 @@ class DiffSingerVarianceExporter(BaseExporter):
             alias_prefix='/variance_predictor/backbone/cache'
         )
         onnx_helper.graph_remove_unused_values(var_diffusion.graph)
-        print(f'Running ONNX Simplifier on {self.multi_var_predictor_class_name}...')
-        var_diffusion = onnx_helper.simplify_onnx(var_diffusion)
+        print(f'Running ONNX Simplifier #2 on {self.multi_var_predictor_class_name}...')
+        var_diffusion, check = onnxsim.simplify(var_diffusion, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
 
-        var_post = onnx_helper.simplify_onnx(var_post)
+        var_post, check = onnxsim.simplify(var_post, include_subgraph=True)
+        assert check, 'Simplified ONNX model could not be validated'
 
-        ignored_variance_names = '|'.join(
-            f'({re.escape(v_name)})' for v_name in self.model.variance_prediction_list
-        ) if self.model.variance_prediction_list else '(?!)'
-        ignored_variance_pred_names = '|'.join(
-            f'({re.escape(v_name)}_pred)' for v_name in self.model.variance_prediction_list
-        ) if self.model.variance_prediction_list else '(?!)'
+        ignored_variance_names = '|'.join([f'({v_name})' for v_name in self.model.variance_prediction_list])
         onnx_helper.model_add_prefixes(
             var_pre, node_prefix='/pre', value_info_prefix='/pre', initializer_prefix='/pre',
-            ignored_pattern=fr'.*((embed)|(variance_cond)|{ignored_variance_names}).*'
+            ignored_pattern=fr'.*((embed)|{ignored_variance_names}).*'
         )
         onnx_helper.model_add_prefixes(var_pre, dim_prefix='pre.', ignored_pattern='(n_tokens)|(n_frames)')
         onnx_helper.model_add_prefixes(
             var_post, node_prefix='/post', value_info_prefix='/post', initializer_prefix='/post',
-            ignored_pattern=fr'.*({ignored_variance_pred_names}).*'
+            ignored_pattern=None
         )
         onnx_helper.model_add_prefixes(var_post, dim_prefix='post.', ignored_pattern='n_frames')
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -6,7 +6,7 @@
 
 DiffSinger requires Python 3.10 or later. We strongly recommend you create a virtual environment via Conda, venv or uv before installing dependencies.
 
-1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using version >= 2.4.0, preferably <= 2.8.0.
+1. Install The latest PyTorch following the [official instructions](https://pytorch.org/get-started/locally/) according to your OS and hardware. We recommend using the latest stable release that is >= 2.4.0.
 
 2. Install other dependencies via the following command:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # It is recommended to install PyTorch manually.
-# PyTorch >= 2.4, preferably <= 2.8 is recommended.
+# PyTorch >= 2.4 is recommended.
 # See instructions at https://pytorch.org/get-started/locally/
 
 click
@@ -11,7 +11,7 @@ matplotlib
 MonkeyType>=23.3.0
 numpy<2.0.0
 onnx>=1.21.0
-onnxslim>=0.1.93
+onnxsim>=0.6.5
 praat-parselmouth==0.4.3
 pyworld==0.3.4
 PyYAML

--- a/utils/onnx_helper.py
+++ b/utils/onnx_helper.py
@@ -28,16 +28,6 @@ TORCHSCRIPT_EXPORT_KWARGS: Dict[str, object] = (
 )
 
 
-def simplify_onnx(model: ModelProto) -> ModelProto:
-    """Simplify an ONNX ModelProto and return the simplified model.
-
-    Unlike ``onnxslim.slim``, this function returns a single ``ModelProto``
-    (not a tuple); validation failures raise instead of returning a flag.
-    """
-    import onnxslim
-    return onnxslim.slim(model)
-
-
 def _verbose(self, *args, sep=' ', end='\n', file=None):
     if __verbose__:
         print(self, *args, sep=sep, end=end, file=file)


### PR DESCRIPTION
Replace usage of onnxslim with onnx-simplifier (onnxsim) across exporters. Exporters now call onnxsim.simplify(..., include_subgraph=True) and assert the returned validation flag. Remove the simplify_onnx helper from utils/onnx_helper.py and update requirements to depend on onnxsim>=0.6.5. Adjust variance exporter prefix/ignored-pattern handling and remove an unused re import. Update GettingStarted.md to clarify the PyTorch recommendation.