### PR TITLE
fix: preserve timestep rank in sinusoidal embedding

### DIFF
--- a/modules/backbones/lynxnet.py
+++ b/modules/backbones/lynxnet.py
@@ -135,6 +135,8 @@ class LYNXNet(nn.Module):
             step = step + (step_2 - step) * mask
         else:
             step = self.diffusion_embedding(diffusion_step)
+            if step.dim() == 2:
+                step = step.unsqueeze(1)
 
         for layer in self.residual_layers:
             x = layer(x, cond, step.transpose(1, 2), front_cond_inject=self.strong_cond)

--- a/modules/backbones/lynxnet2.py
+++ b/modules/backbones/lynxnet2.py
@@ -103,7 +103,10 @@ class LYNXNet2(nn.Module):
             mask = mask.to(x).unsqueeze(-1) # [B, T, 1]
             x = x + step + (step_2 - step) * mask
         else:
-            x = x + self.diffusion_embedding(diffusion_step)
+            step = self.diffusion_embedding(diffusion_step)
+            if step.dim() == 2:
+                step = step.unsqueeze(1)
+            x = x + step
 
         for layer in self.residual_layers:
             x = layer(x)

--- a/modules/backbones/wavenet.py
+++ b/modules/backbones/wavenet.py
@@ -95,6 +95,8 @@ class WaveNet(nn.Module):
         else:
             step = self.diffusion_embedding(diffusion_step)
             step = self.mlp(step)
+            if step.dim() == 2:
+                step = step.unsqueeze(1)
             
         skip = []
         for layer in self.residual_layers:

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -422,8 +422,6 @@ class SinusoidalPosEmb(nn.Module):
         half_dim = self.dim // 2
         emb = math.log(10000) / (half_dim - 1)
         emb = torch.exp(torch.arange(half_dim, device=device) * -emb)
-        if x.dim() == 1:
-            x = x.unsqueeze(-1)
         emb = x.unsqueeze(-1) * emb
         emb = torch.cat((emb.sin(), emb.cos()), dim=-1)
         return emb


### PR DESCRIPTION
## Summary

- preserve the input rank in `SinusoidalPosEmb`
- restore the singleton frame axis after timestep MLPs when tracing rank-1 timesteps
- keep rank-2 dual-timestep training and interpolation behavior unchanged

## Motivation

The ONNX exporters trace diffusion backbones with a rank-1 timestep tensor. Forcing that tensor to rank 2 inside `SinusoidalPosEmb` makes the timestep MLP operate on rank-3 inputs, which exports its linear layers as `MatMul` + `Add`. ONNX Runtime DirectML graph fusion rejects the resulting diffusion loop graph.

Keeping rank-1 timesteps rank 1 lets the linear layers export as 2-D `Gemm`, then the backbone restores the existing `[B, 1, C]` contract. Rank-2 dual timesteps already produce `[B, 1, C]` and are unchanged.

## Validation

- rank-1 and rank-2 timestep paths produce identical `[B, 1, C]` output (`max_abs_error = 0`)
- legacy ONNX export emits two `Gemm` nodes and no `MatMul` for the timestep MLP
- ONNX checker passes
