### PR TITLE
fix: pool frame-level speaker mixes for Mix-LN

### DIFF
--- a/deployment/modules/fastspeech2.py
+++ b/deployment/modules/fastspeech2.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from modules.commons.common_layers import NormalInitEmbedding as Embedding
-from modules.fastspeech.acoustic_encoder import FastSpeech2Acoustic
+from modules.fastspeech.acoustic_encoder import FastSpeech2Acoustic, uniform_attention_pooling
 from modules.fastspeech.variance_encoder import FastSpeech2Variance
 from utils.hparams import hparams
 from utils.phoneme_utils import PAD_INDEX
@@ -16,20 +16,6 @@ f0_max = 1100.0
 f0_min = 50.0
 f0_mel_min = 1127 * np.log(1 + f0_min / 700)
 f0_mel_max = 1127 * np.log(1 + f0_max / 700)
-
-
-def uniform_attention_pooling(spk_embed, durations):
-    _, T_mel, _ = spk_embed.shape
-    ph_starts = torch.cumsum(torch.cat([torch.zeros_like(durations[:, :1]), durations[:, :-1]], dim=1), dim=1)
-    ph_ends = ph_starts + durations
-    mel_indices = torch.arange(T_mel, device=spk_embed.device).view(1, 1, T_mel)
-    phoneme_to_mel_mask = (mel_indices >= ph_starts.unsqueeze(-1)) & (mel_indices < ph_ends.unsqueeze(-1))
-    uniform_scores = phoneme_to_mel_mask.float()
-    sum_scores = uniform_scores.sum(dim=2, keepdim=True)
-    attn_weights = uniform_scores / (sum_scores + (sum_scores == 0).float())  # [B, T_ph, T_mel]
-    ph_spk_embed = torch.bmm(attn_weights, spk_embed)
-
-    return ph_spk_embed
 
 
 def f0_to_coarse(f0):

--- a/modules/fastspeech/acoustic_encoder.py
+++ b/modules/fastspeech/acoustic_encoder.py
@@ -12,6 +12,20 @@ from utils.hparams import hparams
 from utils.phoneme_utils import PAD_INDEX
 
 
+def uniform_attention_pooling(spk_embed, durations):
+    _, T_mel, _ = spk_embed.shape
+    ph_starts = torch.cumsum(torch.cat([torch.zeros_like(durations[:, :1]), durations[:, :-1]], dim=1), dim=1)
+    ph_ends = ph_starts + durations
+    mel_indices = torch.arange(T_mel, device=spk_embed.device).view(1, 1, T_mel)
+    phoneme_to_mel_mask = (mel_indices >= ph_starts.unsqueeze(-1)) & (mel_indices < ph_ends.unsqueeze(-1))
+    uniform_scores = phoneme_to_mel_mask.float()
+    sum_scores = uniform_scores.sum(dim=2, keepdim=True)
+    attn_weights = uniform_scores / (sum_scores + (sum_scores == 0).float())  # [B, T_ph, T_mel]
+    ph_spk_embed = torch.bmm(attn_weights, spk_embed)
+
+    return ph_spk_embed
+
+
 class FastSpeech2Acoustic(nn.Module):
     def __init__(self, vocab_size):
         super().__init__()
@@ -143,7 +157,11 @@ class FastSpeech2Acoustic(nn.Module):
             extra_embed = dur_embed + lang_embed
         else:
             extra_embed = dur_embed
-        encoder_out = self.encoder(txt_embed, extra_embed, txt_tokens == 0, spk_embed)
+        if self.use_mix_ln and spk_embed is not None and spk_embed.shape[1] > 1:
+            ph_spk_embed = uniform_attention_pooling(spk_embed, dur)
+        else:
+            ph_spk_embed = spk_embed
+        encoder_out = self.encoder(txt_embed, extra_embed, txt_tokens == 0, ph_spk_embed)
 
         encoder_out = F.pad(encoder_out, [0, 0, 1, 0])
         mel2ph_ = mel2ph[..., None].repeat([1, 1, encoder_out.shape[-1]])


### PR DESCRIPTION
## Summary

Fix native PyTorch acoustic inference with Mix-LN and dynamic frame-level speaker mixes.

The DS acoustic loader produces `spk_mix_embed` with shape `[B, T_mel, H]`. The native acoustic encoder previously passed it directly to Mix-LN, whose encoder state is `[B, T_ph, H]`, causing a shape mismatch whenever `T_mel != T_ph`.

## Changes

- Move `uniform_attention_pooling()` from the ONNX-only module to the shared acoustic encoder module.
- Pool dynamic frame-level speaker embeddings to phoneme level before using them as the Mix-LN encoder condition in native inference.
- Keep the original frame-level embedding for the post-length-regulator acoustic condition.
- Reuse the same helper from the ONNX wrapper, preserving its existing behavior.
- Leave static `[B, 1, H]` speaker embeddings unchanged so they continue to broadcast normally.

## Verification

- `git diff --check`
- `py_compile` on both modified modules
- Numerical pooling check, including a zero-duration phoneme
- Native dynamic forward: Mix-LN encoder condition is `[B, T_ph, H]` while the acoustic frame condition remains `[B, T_mel, H]`
- Static speaker embedding regression: encoder condition remains `[B, 1, H]`