### PR TITLE
enable mixed-precision for layernorm

### DIFF
--- a/modules/aux_decoder/convnext.py
+++ b/modules/aux_decoder/convnext.py
@@ -3,7 +3,7 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from modules.commons.common_layers import AdamWConv1d
+from modules.commons.common_layers import AdamWConv1d, MixedPrecisionLayerNorm
 
 
 class ConvNeXtBlock(nn.Module):
@@ -26,7 +26,7 @@ class ConvNeXtBlock(nn.Module):
         super().__init__()
         self.dwconv = nn.Conv1d(dim, dim, kernel_size=7, padding=3, groups=dim)  # depthwise conv
 
-        self.norm = nn.LayerNorm(dim, eps=1e-6)
+        self.norm = MixedPrecisionLayerNorm(dim, eps=1e-6)
         self.pwconv1 = nn.Linear(dim, intermediate_dim)  # pointwise/1x1 convs, implemented with linear layers
         self.act = nn.GELU()
         self.pwconv2 = nn.Linear(intermediate_dim, dim)

--- a/modules/backbones/lynxnet.py
+++ b/modules/backbones/lynxnet.py
@@ -7,6 +7,7 @@ import torch.nn.functional as F
 
 from modules.commons.common_layers import SinusoidalPosEmb, SwiGLU, Transpose, AdamWConv1d
 from modules.commons.common_layers import KaimingNormalConv1d as Conv1d
+from modules.commons.common_layers import MixedPrecisionLayerNorm as LayerNorm
 from utils.hparams import hparams
 
 
@@ -34,7 +35,7 @@ class LYNXConvModule(nn.Module):
         else:
             _dropout = nn.Identity()
         self.net = nn.Sequential(
-            nn.LayerNorm(dim),
+            LayerNorm(dim),
             Transpose((1, 2)),
             nn.Conv1d(dim, inner_dim * 2, 1),
             SwiGLU(dim=1),
@@ -104,7 +105,7 @@ class LYNXNet(nn.Module):
                 for _ in range(num_layers)
             ]
         )
-        self.norm = nn.LayerNorm(num_channels)
+        self.norm = LayerNorm(num_channels)
         self.output_projection = AdamWConv1d(num_channels, in_dims * n_feats, kernel_size=1)
         self.strong_cond = strong_cond
         nn.init.zeros_(self.output_projection.weight)

--- a/modules/backbones/lynxnet2.py
+++ b/modules/backbones/lynxnet2.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 from modules.commons.common_layers import (
     SinusoidalPosEmb, SwiGLU, ATanGLU, SoftSignGLU, Transpose, AdamWLinear
 )
+from modules.commons.common_layers import MixedPrecisionLayerNorm as LayerNorm
 from utils.hparams import hparams
 
 
@@ -25,7 +26,7 @@ class LYNXNet2Block(nn.Module):
         else:
             _dropout = nn.Identity()
         self.net = nn.Sequential(
-            nn.LayerNorm(dim),
+            LayerNorm(dim),
             Transpose((1, 2)),
             nn.Conv1d(dim, dim, kernel_size=kernel_size, padding=kernel_size // 2, groups=dim),
             Transpose((1, 2)),
@@ -75,7 +76,7 @@ class LYNXNet2(nn.Module):
                 for _ in range(num_layers)
             ]
         )
-        self.norm = nn.LayerNorm(num_channels)
+        self.norm = LayerNorm(num_channels)
         self.output_projection = AdamWLinear(num_channels, in_dims * n_feats)
         nn.init.kaiming_normal_(self.input_projection.weight)
         nn.init.kaiming_normal_(self.conditioner_projection.weight)

--- a/modules/commons/common_layers.py
+++ b/modules/commons/common_layers.py
@@ -287,6 +287,22 @@ class Mixed_LayerNorm(nn.Module):
         return mixed_gammas * x + mixed_betas
 
 
+class MixedPrecisionLayerNorm(nn.LayerNorm):
+    """LayerNorm that keeps fp16/bf16 activations under AMP autocast"""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        with torch.autocast(device_type=x.device.type, enabled=False):
+            weight = self.weight
+            bias = self.bias
+            if weight is not None and weight.dtype != x.dtype:
+                weight = weight.to(x.dtype)
+            if bias is not None and bias.dtype != x.dtype:
+                bias = bias.to(x.dtype)
+            return F.layer_norm(
+                x, self.normalized_shape, weight, bias, self.eps
+            )
+            
+            
 class TransformerFFNLayer(nn.Module):
     def __init__(self, hidden_size, filter_size, kernel_size=1, dropout=0., act='gelu'):
         super().__init__()


### PR DESCRIPTION
## Summary

Introduce `MixedPrecisionLayerNorm` (a drop-in `nn.LayerNorm` subclass) and use it for the LayerNorms in the LYNXNet / LYNXNet2 diffusion backbones and the ConvNeXt aux decoder, so activations stay in fp16/bf16 under AMP autocast.

## Motivation

Under PyTorch AMP autocast (this project trains with `pl_trainer_precision: '16-mixed'` by default), `layer_norm` is in autocast's fp32 cast-policy list: **every `nn.LayerNorm` outputs fp32 even with fp16 activations**.

The fp32 outputs then flow through ops that autocast does not cast (`Transpose`, GELU/GLU, residual adds, dropout) until the next conv/linear, so all activations saved for backward in that span are stored in fp32 — doubling a large fraction of activation memory for no precision benefit.

## How it works

`MixedPrecisionLayerNorm.forward` disables autocast locally, casts `weight`/`bias` to the activation dtype, and calls `F.layer_norm` directly. Mean/variance are still accumulated in fp32 inside the CUDA kernel; the only extra rounding is a one-time fp16 quantization of the normalized output and of the affine parameters.

`weight`/`bias` must be cast rather than passed through as fp32, because the CUDA `layer_norm` kernel rejects mixed input/weight dtypes (`expected scalar type Half but found Float`); upcasting the activation to fp32 instead would discard the memory saving entirely.

Non-AMP fp32 execution is unchanged (bit-identical to `nn.LayerNorm`), checkpoints stay fully compatible, and ONNX/JIT-exported graphs are identical to before.